### PR TITLE
Fix problem with displaying OVAL graph

### DIFF
--- a/oscap_report/html_report/templates/oval_graph.html
+++ b/oscap_report/html_report/templates/oval_graph.html
@@ -23,7 +23,7 @@
             </div>    
         {%- endif %}
     </div>
-    <div id="oval_tree_of_rule_{{ rule.rule_id | replace('.', '') }}" is_rendered="false" data='{{ rule.oval_tree.as_json() }}'></div>
+    <div id="oval_tree_of_rule_{{ rule.rule_id | replace('.', '') }}" is_rendered="false" data='{{ rule.oval_tree.as_dict() | tojson }}'></div>
 {% else %}
 <div class="pf-c-alert pf-m-warning pf-m-inline">
     <div class="pf-c-alert__icon">


### PR DESCRIPTION
This PR fixes problem with escaping of quote char in JSON which is saved as HTML attribute for OVAL graph.