### PR TITLE
Fix centos stream 9 CI

### DIFF
--- a/.github/workflows/package_dependency_test.yaml
+++ b/.github/workflows/package_dependency_test.yaml
@@ -12,7 +12,7 @@ jobs:
       image: quay.io/centos/centos:stream9
     steps:
       - name: Install Deps
-        run: dnf install -y python3-devel python3-setuptools rpm-build python3
+        run: dnf install -y python3-devel python3-setuptools rpm-build
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
This PR removes `python3` from the installation of dependencies because `python3` is installed by default.