### PR TITLE
Online CSS in debug mode

### DIFF
--- a/openscap_report/cli.py
+++ b/openscap_report/cli.py
@@ -28,7 +28,8 @@ LOG_LEVES_DESCRIPTION = (
 DEBUG_FLAGS_DESCRIPTION = (
     "DEBUG FLAGS:\n"
     "\tNO-MINIFY - The HTML report is not minified.\n"
-    "\tBUTTON-SHOW-ALL-RULES - Adds the button that shows all rules."
+    "\tBUTTON-SHOW-ALL-RULES - Adds the button that shows all rules.\n"
+    "\tONLINE-CSS - Use the latest online version of Patternfly"
 )
 
 MASSAGE_FORMAT = '%(levelname)s: %(message)s'
@@ -114,7 +115,7 @@ class CommandLineAPI():  # pylint: disable=R0902
             action="store",
             nargs='+',
             default=[""],
-            choices=["NO-MINIFY", "BUTTON-SHOW-ALL-RULES"],
+            choices=["NO-MINIFY", "BUTTON-SHOW-ALL-RULES", "ONLINE-CSS"],
             help=f"{DEBUG_FLAGS_DESCRIPTION}"
         )
 
@@ -160,6 +161,7 @@ class DebugSetting():
     options_require_debug_script: tuple = ("BUTTON-SHOW-ALL-RULES", )
     include_debug_script: bool = False
     button_show_all_rules: bool = False
+    use_online_css: bool = False
 
     def update_settings_with_debug_flags(self, debug_flags):
         for flag in debug_flags:
@@ -169,6 +171,8 @@ class DebugSetting():
                 self.no_minify = True
             if flag == "BUTTON-SHOW-ALL-RULES":
                 self.button_show_all_rules = True
+            if flag == "ONLINE-CSS":
+                self.use_online_css = True
 
 
 def main():

--- a/openscap_report/html_report/templates/template_report.html
+++ b/openscap_report/html_report/templates/template_report.html
@@ -19,9 +19,13 @@
 {% endblock %}
 
 {% block patternfly_css %}
+{% if  debug_setting.use_online_css %}
+ <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly/patternfly.css" crossorigin="anonymous">
+{% else %}
 <style>
     {%- include './css/patternfly.css' -%}
 </style>
+{% endif %}
 {% endblock %}
 
 {% block title%}OpenSCAP Evaluation Report{% endblock %}


### PR DESCRIPTION
This PR creates a version of the report with online CSS. After using debug option ```ONLINE-CSS```. The version of this report uses the latest version of PatternFly but needs an internet connection.