### PR TITLE
Fix the issue that causes displaying all rules

### DIFF
--- a/openscap_report/html_report/__init__.py
+++ b/openscap_report/html_report/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from .exceptions import FilterNotSupportDataStructureException
 from .report_generator import ReportGenerator

--- a/openscap_report/html_report/exceptions.py
+++ b/openscap_report/html_report/exceptions.py
@@ -1,0 +1,5 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+class FilterNotSupportDataStructureException(Exception):
+    """ Raised when filter try to process not supported data structures """

--- a/openscap_report/html_report/report_generator.py
+++ b/openscap_report/html_report/report_generator.py
@@ -15,6 +15,9 @@ except ImportError:
 
 from markupsafe import Markup
 
+from ..scap_results_parser.data_structures import Rule
+from .exceptions import FilterNotSupportDataStructureException
+
 
 class ReportGenerator():
     def __init__(self, parser):
@@ -23,6 +26,7 @@ class ReportGenerator():
         self.env = Environment(loader=self.file_loader)
         self.env.globals['include_file_in_base64'] = self.include_file_in_base64
         self.env.filters['set_css_for_list'] = self.set_css_for_list
+        self.env.filters['get_selected_rules'] = self.get_selected_rules
         self.env.trim_blocks = True
         self.env.lstrip_blocks = True
 
@@ -47,4 +51,14 @@ class ReportGenerator():
     def set_css_for_list(data):
         out = data.replace("<ul>", "<ul class=\"pf-c-list\">")
         out = out.replace("<ol>", "<ol class=\"pf-c-list\">")
+        return out
+
+    @staticmethod
+    def get_selected_rules(data):
+        out = []
+        for rule_id, rule in data.items():
+            if not isinstance(rule, Rule):
+                raise FilterNotSupportDataStructureException
+            if rule.result != "notselected":
+                out.append((rule_id, rule))
         return out

--- a/openscap_report/html_report/templates/rules_overview.html
+++ b/openscap_report/html_report/templates/rules_overview.html
@@ -15,15 +15,13 @@
             </th>
         </tr>
     </thead>
-    {% set count = 1 %}
-    {% for rule_id, rule in report.rules.items() %}
+    {% for rule_id, rule in report.rules|get_selected_rules %}
     {%- if rule.result != "notselected" -%}
-        {% if count > 50 %}
+        {% if loop.index > 50 %}
             <tbody class="pf-m-expanded hidden" role="rowgroup" title="{{ rule.title }}" rule-id="{{ rule.rule_id }}" result="{{ rule.result }}" severity="{{ rule.severity }}">
         {% else %}
             <tbody class="pf-m-expanded" role="rowgroup" title="{{ rule.title }}" rule-id="{{ rule.rule_id }}" result="{{ rule.result }}" severity="{{ rule.severity }}">
         {% endif %}
-        {% set count = count + 1 %}
         <tr role="row">
             <td class="pf-c-table__toggle" role="cell">
                 <button


### PR DESCRIPTION
This PR fixes the problem with counting in jinja macros that cause showing all rules instead only the first 50 rules. Other rules in the report are displayed when the user scrolls. 