### PR TITLE
Fix minify of html report

### DIFF
--- a/openscap_report/html_report/report_generator.py
+++ b/openscap_report/html_report/report_generator.py
@@ -29,7 +29,7 @@ class ReportGenerator():
     def generate_html_report(self, debug_setting):
         template = self.env.get_template("template_report.html")
         html_report = template.render(report=self.report, debug_setting=debug_setting)
-        if not debug_setting.no_minify:
+        if debug_setting.no_minify:
             return BytesIO(html_report.encode())
         minified_html_report = re.sub(r'>\s+<', '><', html_report)
         return BytesIO(minified_html_report.encode())

--- a/openscap_report/html_report/templates/rule_detail.html
+++ b/openscap_report/html_report/templates/rule_detail.html
@@ -111,12 +111,12 @@
                     <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
                     <p class="pf-c-table__text">
                     <div>
-                        {% for identifier in rule.identifiers -%}
-                        {% if identifier.href %}
+                        {%- for identifier in rule.identifiers -%}
+                        {%- if identifier.href -%}
                             <a href="{{ identifier.href | replace('&', ';') }}">{{ identifier.text }}</a>
-                        {% else %}
+                        {%- else -%}
                             <a href="identifier_href_not_found">{{ identifier.text }}</a>
-                        {% endif %}
+                        {%- endif -%}
                         {{- ", " if not loop.last else "" -}}
                         {%- endfor %}
                     </div>
@@ -132,14 +132,14 @@
                     <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
                     <p class="pf-c-table__text">
                     <div>
-                        {% for reference in rule.references -%}
-                        {% if reference.href %}
+                        {%- for reference in rule.references -%}
+                        {%- if reference.href -%}
                             <a href="{{ reference.href | replace('&', ';') }}">{{ reference.text }}</a>
-                        {% else %}
+                        {%- else -%}
                             <a href="reference_href_not_found">{{ reference.text }}</a>
-                        {% endif %}
+                        {%- endif -%}
                         {{- ", " if not loop.last else "" -}}
-                        {%- endfor %}
+                        {%- endfor -%}
                     </div>
                     </p>
                     </div></div>


### PR DESCRIPTION
This PR fixes the inverted logic of debug option `NO-MINIFY` and removes white spaces that are problematic to remove with regex. 