### PR TITLE
Fix sub-element reference that do not exist

### DIFF
--- a/openscap_report/html_report/templates/base_report.html
+++ b/openscap_report/html_report/templates/base_report.html
@@ -128,6 +128,12 @@
         .icon-space {
             margin-right: 5px;
         }
+
+        .error-id-ref {
+            color: red;
+            background-color: yellow;
+            font-weight: 900;
+        }
     </style>
 </head>
 

--- a/openscap_report/scap_results_parser/parsers/full_text_parser.py
+++ b/openscap_report/scap_results_parser/parsers/full_text_parser.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import html
+import logging
 
 from lxml import etree
 
@@ -13,7 +14,12 @@ class FullTextParser():
         self.ref_values = ref_values
 
     def replace_sub_tag(self, tag):
-        return self.ref_values.get(tag.get("idref"))
+        id_ref = tag.get("idref")
+        if id_ref in self.ref_values:
+            return self.ref_values.get(id_ref)
+        error_msg = f"Sub tag reference does not exist: {id_ref}"
+        logging.warning(error_msg)
+        return f"<span class='error-id-ref'>{error_msg}</span>"
 
     @staticmethod
     def _get_html_attributes_as_string(attributes):

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -17,7 +17,9 @@ PATH_TO_ARF_WITHOUT_SYSTEM_DATA = Path(__file__).parent / "test_data/arf_no_syst
 PATH_TO_ARF_WITH_MULTI_CHECK = Path(__file__).parent / "test_data/arf_multi_check.xml"
 PATH_TO_ARF_WITH_OS_CPE_CHECK = Path(__file__).parent / "test_data/arf_cpe_check_os_platform.xml"
 PATH_TO_ARF_SCANNED_ON_CONTAINER = Path(__file__).parent / "test_data/arf-container.xml"
-
+PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO = (
+    Path(__file__).parent / "test_data/arf-dangling-reference-to.xml"
+)
 
 PATH_TO_XCCDF = Path(__file__).parent / "test_data/xccdf-report.xml"
 PATH_TO_SIMPLE_RULE_FAIL_XCCDF = Path(__file__).parent / "test_data/xccdf_simple_rule_fail.xml"

--- a/tests/unit_tests/test_full_text_parser.py
+++ b/tests/unit_tests/test_full_text_parser.py
@@ -1,0 +1,86 @@
+import pytest
+from lxml import etree
+
+from openscap_report.scap_results_parser import SCAPResultsParser
+from openscap_report.scap_results_parser.parsers import FullTextParser
+
+from ..constants import (PATH_TO_ARF,
+                         PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO)
+
+REF_VALUES = {
+    "id-1234": "text1",
+    "1234": 'echo "nwm"'
+}
+FULL_TEXT_PARSER = FullTextParser(REF_VALUES)
+
+
+@pytest.mark.unit_test
+@pytest.mark.parametrize("tag, return_data", [
+    (etree.Element("sub", idref="id-1234"), "text1"),
+    (etree.Element("sub", idref="1234"), 'echo "nwm"'),
+    (
+        etree.Element("sub", idref="hello-ID"),
+        "<span class='error-id-ref'>Sub tag reference does not exist: hello-ID</span>"
+    ),
+])
+def test_replace_sub_tag(tag, return_data):
+    assert FULL_TEXT_PARSER.replace_sub_tag(tag) == return_data
+
+
+def get_report(src):
+    with open(src, "r") as report_file:
+        return SCAPResultsParser(report_file.read().encode()).parse_report()
+
+
+BASIC_REPORT = get_report(PATH_TO_ARF)
+REPORT_REPRODUCING_DANGLING_REFERENCE_TO = get_report(
+    PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO
+)
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize("report, rule_id, expected_data", [
+    (
+        REPORT_REPRODUCING_DANGLING_REFERENCE_TO,
+        "xccdf_org.ssgproject.content_rule_grub2_l1tf_argument",
+        (
+            "L1 Terminal Fault (L1TF) is a hardware vulnerability which allows unprivileged\n"
+            "speculative access to data which is available in the Level 1 Data Cache when\n"
+            "the page table entry isn&#x27;t present.\n\nSelect the appropriate mitigation by"
+            " adding the argument\n<code>l1tf=<span class='error-id-ref'>"
+            "Sub tag reference does not exist: dangling reference to !</span>"
+            "</code> to the default\nGRUB 2 command line for the Linux operating system.\n"
+            "Configure the default Grub2 kernel command line to contain "
+            "l1tf=xccdf_value(var_l1tf_options) as follows:\n"
+            "<pre># grub2-editenv - set &quot;$(grub2-editenv - list | grep kernelopts) "
+            "l1tf=xccdf_value(var_l1tf_options)&quot;</pre>\n\nSince Linux Kernel 4.19 "
+            "you can check the L1TF vulnerability state with the\n"
+            "following command:\n<code>cat /sys/devices/system/cpu/vulnerabilities/l1tf</code>"
+        )
+    ),
+    (
+        BASIC_REPORT,
+        "xccdf_org.ssgproject.content_rule_postfix_client_configure_mail_alias",
+        (
+            "Make sure that mails delivered to root user are forwarded to a monitored\n"
+            "email address. Make sure that the address\nsystem.administrator@mail.mil is"
+            " a valid email address\nreachable from the system in question. Use the following"
+            " command to\nconfigure the alias:\n<pre>$ sudo echo &quot;root: "
+            "system.administrator@mail.mil&quot; &gt;&gt; /etc/aliases\n$ sudo newaliases</pre>"
+        )
+    ),
+    (
+        REPORT_REPRODUCING_DANGLING_REFERENCE_TO,
+        "xccdf_org.ssgproject.content_rule_postfix_client_configure_mail_alias",
+        (
+            "Make sure that mails delivered to root user are forwarded to a monitored\n"
+            "email address. Make sure that the address\nsystem.administrator@mail.mil is"
+            " a valid email address\nreachable from the system in question. Use the following"
+            " command to\nconfigure the alias:\n<pre>$ sudo echo &quot;root: "
+            "system.administrator@mail.mil&quot; &gt;&gt; /etc/aliases\n$ sudo newaliases</pre>"
+        )
+    ),
+])
+def test_parsing_of_text(report, rule_id, expected_data):
+    print(repr(report.rules[rule_id].description))
+    assert report.rules[rule_id].description == expected_data


### PR DESCRIPTION
This PR fixes the problem with sub-element references that do not exist. This problem occurred with the ARF report generated on Fedora 37 rawhide with `openscap-1.3.6-10.fc37`, `scap-security-guide-0.1.62-3.fc37`. Reference Id in sub-element is `dangling reference to !`.
 
[The reproducer file](https://github.com/OpenSCAP/openscap-report/blob/42bd69684f715870b37d64bf04a8d7aa5b0596ba/tests/test_data/arf-dangling-reference-to.xml)  