### PR TITLE
Fix FIRST_HIDDEN_ELEMENT is null

### DIFF
--- a/openscap_report/html_report/templates/js/interactive_script.js
+++ b/openscap_report/html_report/templates/js/interactive_script.js
@@ -45,7 +45,7 @@ function get_next_five_rules() {
     for(let i = 0; i <= count_five && FIRST_HIDDEN_ELEMENT !== null; i += 1) {
         next_five_rules.push(FIRST_HIDDEN_ELEMENT);
         FIRST_HIDDEN_ELEMENT = FIRST_HIDDEN_ELEMENT.nextSibling;
-        if (!(FIRST_HIDDEN_ELEMENT instanceof HTMLElement)) {
+        if (!(FIRST_HIDDEN_ELEMENT instanceof HTMLElement) && FIRST_HIDDEN_ELEMENT !== null) {
             FIRST_HIDDEN_ELEMENT = FIRST_HIDDEN_ELEMENT.nextSibling;
         }
     }


### PR DESCRIPTION
This PR fixes the problem of the unexpected null value of the `FIRST_HIDDEN_ELEMENT` variable. 

How reproduce:
* It is caused by scrolling down through the report. 
* Error message will appear in the browsers Javascript console

Why:
* The report uses lazy loading to display the table with rules. When there are no more rules to show. Value of `.nextSibling` is `null`.  