### PR TITLE
Update Nodejs actions

### DIFF
--- a/.github/workflows/package_dependency_test.yaml
+++ b/.github/workflows/package_dependency_test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Deps
         run: dnf install -y python3-devel python3-setuptools rpm-build
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: python3 setup.py bdist_rpm --requires=python3-lxml,python3-jinja2 --build-requires=python3-devel,python3-setuptools
       - name: RPM install
@@ -33,7 +33,7 @@ jobs:
       - name: Install Deps
         run: dnf install -y python3-devel python3-setuptools rpm-build
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: python3 setup.py bdist_rpm --requires=python3-lxml,python3-jinja2 --build-requires=python3-devel,python3-setuptools
       - name: RPM install
@@ -54,7 +54,7 @@ jobs:
       - name: Fix missing Deps
         run: dnf install -y python3-devel python3-setuptools rpm-build
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: python3 setup.py bdist_rpm --requires=python3-lxml,python3-jinja2 --build-requires=python3-devel,python3-setuptools
       - name: RPM install


### PR DESCRIPTION
This PR updates Nodejs actions.

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout