### PR TITLE
Fix OVAL graphs and CPE graphs

### DIFF
--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -28,9 +28,10 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
             )
             self.oval_definitions = self.oval_definition_parser.get_oval_definitions()
             self.oval_cpe_definitions = self.oval_definition_parser.get_oval_cpe_definitions()
-        except MissingOVALResult:
-            logging.warning("Not found OVAL results!")
-            self.missing_oval_results = True
+        except MissingOVALResult as error:
+            logging.warning("OVAL results \"%s\" not found!", error)
+            if str(error) != "oval1":
+                self.missing_oval_results = True
 
     def get_platform_to_oval_cpe_id_dict(self):
         cpe_list = self.root.find(".//ds:component/cpe-dict:cpe-list", NAMESPACES)
@@ -50,7 +51,7 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
             cpe_oval_id = self.platform_to_oval_cpe_id[platform]
         if cpe_oval_id in self.oval_cpe_definitions:
             return self.oval_cpe_definitions[cpe_oval_id].oval_tree
-        logging.warning("There is no CPE check for platform: %s", platform)
+        logging.warning("There is no CPE check for the platform \"%s\".", platform)
         return None
 
     def _insert_platforms_cpe_trees_to_rule_cpe_tree(self, rule, rule_cpe_tree):

--- a/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
@@ -42,7 +42,7 @@ class OVALDefinitionParser:
 
     def _get_oval_definitions(self, oval):
         if oval not in self.oval_definitions:
-            raise MissingOVALResult
+            raise MissingOVALResult(oval)
 
         definitions = {}
         dict_of_criteria = {}

--- a/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
@@ -92,7 +92,7 @@ class OVALDefinitionParser:
             self._set_oval_tree_to_definition(definitions, definition_id, oval_tree_source)
 
     def _set_oval_tree_to_definition(self, definitions, definition_id, oval_tree_source):
-        if definition_id in self.oval_trees:
+        if definition_id in oval_tree_source:
             oval_tree_source[definition_id].comment = definitions[definition_id].description
             definitions[definition_id].oval_tree = oval_tree_source[definition_id]
 


### PR DESCRIPTION
This PR fixes errors associated with the processing of OVAL graphs and CPE graphs.
* Fixes a missing key error caused by a platform without an OVAL definition
* Fixes missing CPE graph in the report
* Fixes missing OVAL definitions in the report when not present in OVAL CPE checks