### PR TITLE
Add srpm_build_deps to Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,15 @@ downstream_package_name: openscap-report
 # version tag template
 upstream_tag_template: v{version}
 
+srpm_build_deps:
+  - python3-devel
+  - python3-sphinx
+  - python3-sphinx_rtd_theme
+  - python3-jinja2
+  - python3-lxml
+  - redhat-display-fonts
+  - redhat-text-fonts
+
 actions:
   get-current-version:
     - python3 setup.py --version


### PR DESCRIPTION
This PR adds `srpm_build_deps` according to this message: All SRPMs will be built in Copr since January 2023. Please use [srpm_build_deps](https://packit.dev/docs/configuration/#srpm_build_deps) to be sure that we don't break your workflow once we switch to building all SRPMs in Copr.