### PR TITLE
Fix XCCDF support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@
 *.woff
 *.woff2
 *.jpg
+*.dtd

--- a/openscap_report/cli.py
+++ b/openscap_report/cli.py
@@ -14,7 +14,7 @@ from .report_generators import (HTMLReportGenerator,
                                 JSONEverythingReportGenerator,
                                 JSONReportGenerator,
                                 OldStyleHTMLReportGenerator)
-from .scap_results_parser import SCAPResultsParser
+from .scap_results_parser import NotSupportedReportingFormat, SCAPResultsParser
 
 DESCRIPTION = ("Generates an HTML report from an ARF (or XCCDF Result) file with results of "
                "a SCAP-compatible utility scan. Unless the --output option is specified "
@@ -44,7 +44,7 @@ DEBUG FLAGS:
 """
 
 MASSAGE_FORMAT = '%(levelname)s: %(message)s'
-EXPECTED_ERRORS = (XMLSyntaxError, )
+EXPECTED_ERRORS = (XMLSyntaxError, NotSupportedReportingFormat)
 EXIT_FAILURE_CODE = 1
 EXIT_SUCCESS_CODE = 0
 

--- a/openscap_report/report_generators/html_templates/cpe_graph.html
+++ b/openscap_report/report_generators/html_templates/cpe_graph.html
@@ -16,7 +16,7 @@
             There is no CPE applicability check.<br>
         </p>
     </div>
-{%- endif %}
+{%- else -%}
 {% for key, platforms in platforms_dict.items() %}
 {% if platforms %}
 {% if key == 'profile_platforms' -%}
@@ -71,3 +71,4 @@
 {% endfor %}
 {%- endif %}
 {% endfor %}
+{%- endif %}

--- a/openscap_report/report_generators/html_templates/template_report.html
+++ b/openscap_report/report_generators/html_templates/template_report.html
@@ -39,10 +39,13 @@
 {% block title%}OpenSCAP Evaluation Report{% endblock %}
 
 {% block content %}
+
+{% if report.profile_info.title|length and report.profile_info.description|length -%}
 <h2 class="pf-c-title pf-m-3xl">About profile</h2>
 <br>
 {% include 'profile_info.html' %}
 <br>
+{%- endif -%}
 
 <h2 class="pf-c-title pf-m-3xl">Compliance and Scoring</h2>
 <br>

--- a/openscap_report/scap_results_parser/__init__.py
+++ b/openscap_report/scap_results_parser/__init__.py
@@ -1,5 +1,7 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from .exceptions import MissingOVALResult, MissingProcessableRules
-from .scap_results_parser import SCAPResultsParser
+from .exceptions import (MissingOVALResult, MissingProcessableRules,
+                         NotSupportedReportingFormat)
+from .scap_results_parser import (ARF_SCHEMAS_PATH, SCHEMAS_DIR,
+                                  XCCDF_1_2_SCHEMAS_PATH, SCAPResultsParser)

--- a/openscap_report/scap_results_parser/data_structures/report.py
+++ b/openscap_report/scap_results_parser/data_structures/report.py
@@ -43,10 +43,13 @@ class Report:
                 for rule_id, rule in self.rules.items()
                 if rule.result != "notselected"
             ]
-        return [
-            (rule_id, self.rules[rule_id])
-            for rule_id in self.profile_info.selected_rules_ids
-        ]
+        out = []
+        for rule_id in self.profile_info.selected_rules_ids:
+            if rule_id in self.rules:
+                out.append((rule_id, self.rules[rule_id]))
+            else:
+                logging.warning("Missing definition of selected rule: '%s'", rule_id)
+        return out
 
     def get_rule_results_stats(self):
         results_stats = {

--- a/openscap_report/scap_results_parser/exceptions.py
+++ b/openscap_report/scap_results_parser/exceptions.py
@@ -11,3 +11,7 @@ class MissingProcessableRules(Exception):
 
 class ExceptionNoCPEApplicabilityLanguage(Exception):
     """Raise when there is no CPE Applicability Language platform specification"""
+
+
+class NotSupportedReportingFormat(Exception):
+    """Raise when the given input isn't a valid ARF report or XCCDF report"""

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -107,7 +107,7 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
         for rule in rules.values():
             if rule.oval_definition_id in self.oval_definitions:
                 rule.oval_definition = self.oval_definitions[rule.oval_definition_id]
-            rule_group = self.group_parser.rule_to_grup_id[rule.rule_id]
+            rule_group = self.group_parser.rule_to_grup_id.get(rule.rule_id, "")
             group_platforms = self.group_parser.group_to_platforms.get(rule_group, [])
             self._remove_double_cpe_requirement(rule, group_platforms)
             if not self.cpe_al:

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -32,7 +32,9 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
             self.oval_cpe_definitions = self.oval_definition_parser.get_oval_cpe_definitions()
             self._load_cpe_platforms()
         except MissingOVALResult as error:
-            logging.warning("OVAL results \"%s\" not found!", error)
+            logging.warning((
+                "The given input doesn't contain OVAL results (\"%s\"),"
+                " OVAL details won't be shown in the report."), error)
             if str(error) != "oval1":
                 self.missing_oval_results = True
 

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -107,7 +107,7 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
         for rule in rules.values():
             if rule.oval_definition_id in self.oval_definitions:
                 rule.oval_definition = self.oval_definitions[rule.oval_definition_id]
-            rule_group = self.group_parser.rule_to_grup_id.get(rule.rule_id, "")
+            rule_group = self.group_parser.rule_to_group_id.get(rule.rule_id, "")
             group_platforms = self.group_parser.group_to_platforms.get(rule_group, [])
             self._remove_double_cpe_requirement(rule, group_platforms)
             if not self.cpe_al:

--- a/openscap_report/scap_results_parser/parsers/group_parser.py
+++ b/openscap_report/scap_results_parser/parsers/group_parser.py
@@ -13,7 +13,7 @@ class GroupParser:
         self.root = root
         self.benchmark_el = benchmark_el
         self.description_parser = FullTextParser(ref_values)
-        self.rule_to_grup_id = {}
+        self.rule_to_group_id = {}
         self.group_to_platforms = {}
 
     def insert_to_dict_group_to_platforms(self, group_dict, platforms):
@@ -36,7 +36,7 @@ class GroupParser:
 
     def _append_rule_id_to_group_dict(self, group_dict, item):
         group_dict["rules_ids"].append(item.get("id"))
-        self.rule_to_grup_id[item.get("id")] = group_dict.get("group_id")
+        self.rule_to_group_id[item.get("id")] = group_dict.get("group_id")
 
     def get_group(self, group_el, platforms=None):
         if platforms is None:

--- a/openscap_report/scap_results_parser/parsers/oval_result_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_result_parser.py
@@ -30,7 +30,7 @@ class OVALResultParser:
         oval_reports = {}
         reports = self.root.find('.//arf:reports', NAMESPACES)
         if reports is None:
-            raise MissingOVALResult
+            raise MissingOVALResult("all_OVAL_results")
 
         for report in reports:
             report_id = report.get("id")

--- a/openscap_report/scap_results_parser/schemas/xccdf/1.2/XMLSchema.dtd
+++ b/openscap_report/scap_results_parser/schemas/xccdf/1.2/XMLSchema.dtd
@@ -1,0 +1,402 @@
+<!-- DTD for XML Schemas: Part 1: Structures
+     Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
+     Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
+<!-- $Id: XMLSchema.dtd,v 1.30 2001/03/16 15:23:02 ht Exp $ -->
+<!-- Note this DTD is NOT normative, or even definitive. -->           <!--d-->
+<!-- prose copy in the structures REC is the definitive version -->    <!--d-->
+<!-- (which shouldn't differ from this one except for this -->         <!--d-->
+<!-- comment and entity expansions, but just in case) -->              <!--d-->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XML Schema namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XML Schema namespace is almost certainly not
+     a valid schema. -->
+
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema: Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overriden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % notation "%p;notation">
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the schema for schemas -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % particleAndAttrs '((%mgs; | %group;)?, %attrDecls;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '((%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%include; | %import; | %redefine; | %annotation;)*,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the Schema for Schemas,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+ 
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name      %NCName;                        #IMPLIED
+          id        ID                              #IMPLIED
+          abstract  %boolean;                       #IMPLIED
+          final     %complexDerivationSet;          #IMPLIED
+          block     %complexDerivationSet;          #IMPLIED
+          mixed (true|false) 'false'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overriden if complexContent
+     has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; (%restriction;|%extension;)>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; (%restriction;|%extension;)>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the 
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; (%particleAndAttrs;)>
+<!ATTLIST %extension;
+          base  %QName;      #REQUIRED
+          id    ID           #IMPLIED
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else the ur-type, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group; 
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;)*)>
+<!ATTLIST %all;
+          minOccurs   (1)                    #IMPLIED
+          maxOccurs   (1)                    #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+<!-- Note that if order is 'all', group is not allowed inside.
+     If order is 'all' THIS group must be alone (or referenced alone) at
+     the top level of a content model -->
+<!-- If order is 'all', minOccurs==maxOccurs==1 on element/any inside -->
+<!-- Should allow minOccurs=0 inside order='all' . . . -->
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  '##any'
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              '##any'
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace is interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name      %NCName;      #IMPLIED
+          id        ID            #IMPLIED
+          ref       %QName;       #IMPLIED
+          type      %QName;       #IMPLIED
+          use       (prohibited|optional|required) #IMPLIED
+          default   CDATA         #IMPLIED
+          fixed     CDATA         #IMPLIED
+          form      %formValues;  #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name     %NCName;       #REQUIRED
+	  refer    %QName;        #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+	  name        %NCName;    #REQUIRED
+	  id          ID          #IMPLIED
+	  public      CDATA       #REQUIRED
+	  system      %URIref;    #IMPLIED
+	  %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >

--- a/openscap_report/scap_results_parser/schemas/xccdf/1.2/cpe-language_2.3.xsd
+++ b/openscap_report/scap_results_parser/schemas/xccdf/1.2/cpe-language_2.3.xsd
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:cpe="http://cpe.mitre.org/language/2.0"
+    xmlns:cpe-name="http://cpe.mitre.org/naming/2.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    targetNamespace="http://cpe.mitre.org/language/2.0" elementFormDefault="qualified"
+    attributeFormDefault="unqualified" version="2.3">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../common/xml.xsd"/>
+    <xsd:import namespace="http://cpe.mitre.org/naming/2.0" schemaLocation="../../cpe/2.3/cpe-naming_2.3.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation xml:lang="en">This XML Schema defines the CPE Applicability Language. An individual CPE Name
+            addresses a single part of an actual system. To identify more complex platform types, there needs to be a
+            way to combine different CPE Names using logical operators. For example, there may be a need to identify a
+            platform with a particular operating system AND a certain application. The CPE Applicability Language exists
+            to satisfy this need, enabling the CPE Name for the operating system to be combined with the CPE Name for
+            the application. For more information, consult the CPE Applicability Language Specification document. </xsd:documentation>
+        <xsd:appinfo>
+            <schema>CPE Applicability Language</schema>
+            <author>Neal Ziring, Andrew Buttner, David Waltermire</author>
+            <version>2.3</version>
+            <date>2011-07-29</date>
+        </xsd:appinfo>
+        <xsd:appinfo>
+            <!-- Declare the namespaces for schematron -->
+            <sch:ns prefix="cpe" uri="http://cpe.mitre.org/language/2.0"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+
+    <!-- =============================================================================== -->
+    <!-- =============================================================================== -->
+    <!-- =============================================================================== -->
+    <xsd:element name="platform-specification" type="cpe:platformSpecificationType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">This element is the root element of a CPE Applicability Language XML
+                document and therefore acts as a container for child platform definitions.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:key name="platformKey">
+            <xsd:selector xpath="cpe:platform"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+    </xsd:element>
+
+    <xsd:element name="platform" type="cpe:PlatformType"/>
+    <xsd:element name="platform-configuration" type="cpe:PlatformBaseType"/>
+
+    <xsd:element name="logical-test" type="cpe:LogicalTestType">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <sch:pattern id="nonexistent-child">
+                    <sch:rule context="cpe:logical-test">
+                        <sch:assert
+                            test="count(cpe:logical-test) > 0 or count(cpe:fact-ref) > 0 or count(cpe:check-fact-ref) > 0"
+                            >All logical-test elements must contain one or more child logical-test, fact-ref, and/or
+                            check-fact-ref elements.</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="fact-ref" type="cpe:CPEFactRefType"/>
+    <xsd:element name="check-fact-ref" type="cpe:CheckFactRefType"/>
+
+    <!-- =============================================================================== -->
+    <!-- =========================== PLATFORM SPECIFICATION ============================ -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="platformSpecificationType">
+        <xsd:sequence>
+            <xsd:element ref="cpe:platform" minOccurs="1" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- =============================================================================== -->
+    <!-- ==================================  PLATFORM  ================================= -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="PlatformBaseType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The description or qualifications of a particular IT platform type. The
+                platform is defined by the logical-test child element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="title" type="cpe:TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A human-readable title for a platform. To support uses intended for
+                        multiple languages, the title element supports the ‘xml:lang’ attribute. At most one title
+                        element can appear for each language.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="remark" type="cpe:TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">An additional description. To support uses intended for multiple
+                        languages, the remark element supports the ‘xml:lang’ attribute. There can be multiple remarks
+                        for a single language.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="cpe:logical-test" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Definition of test using logical operators (AND, OR,
+                        negate).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PlatformType">
+        <xsd:complexContent>
+            <xsd:extension base="cpe:PlatformBaseType">
+                <xsd:attribute name="id" type="xsd:anyURI" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A locally unique name for the platform. There is no defined
+                            format for this id; however, it must be unique within the containing CPE Applicability
+                            Language document.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="LogicalTestType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The logical-test element appears as a child of a platform element, and may
+                also be nested to create more complex logical tests. The content consists of one or more elements:
+                fact-ref, check-fact-ref, and logical-test children are permitted. The operator to be applied, and
+                optional negation of the test, are given as attributes.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="logical-test" type="cpe:LogicalTestType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Definition of complex logical test using AND, OR, and/or negate
+                        operators. Evaluates to a TRUE, FALSE, or ERROR result. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="cpe:fact-ref" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A reference to a bound form of a WFN; the reference always
+                        evaluates to a boolean result. The bound name contained within a fact-ref is meant to describe a
+                        possible set of products and is not meant to identify a unique product
+                        class.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="cpe:check-fact-ref" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A reference to a check that always evaluates to TRUE, FALSE, or
+                        ERROR. Examples of types of checks are OVAL and OCIL checks.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="operator" type="cpe:operatorEnumeration" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The operator applied to the results of evaluating the fact-ref,
+                    check-fact-ref, and logical-test elements. The permitted operators are "AND" and
+                    "OR".</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="negate" type="xsd:boolean" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Whether the result of applying the operator should be negated. Possible
+                    values are "TRUE" and "FALSE". This does not apply if the initial result is
+                    ERROR.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    <xsd:complexType name="FactRefType">
+        <xsd:attribute name="description" type="xsd:normalizedString" use="optional"/>
+    </xsd:complexType>
+    <xsd:complexType name="CPEFactRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">A reference to a CPE Name that always evaluates to a Boolean
+                result.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cpe:FactRefType">
+                <xsd:attribute name="name" type="cpe:namePattern" use="required"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="CheckFactRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">A reference to a check that always evaluates to a TRUE, FALSE, or ERROR
+                result.</xsd:documentation>
+            <xsd:documentation xml:lang="en">The CheckFactRefType complex type is used to define an element for holding
+                information about an individual check. It includes a checking system specification URI, string content
+                identifying the check content to invoke, and an external reference. The checking system specification
+                should be the URI that uniquely identifies a revision of a check system language, and the id-ref will be
+                an identifier of a test written in that language. The external reference should be used to point to the
+                content in which the check identifier is defined.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cpe:FactRefType">
+                <xsd:attribute name="system" type="xsd:anyURI" use="required"/>
+                <xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+                <xsd:attribute name="id-ref" type="xsd:token" use="required"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- =============================================================================== -->
+    <!-- ===============================  ENUMERATIONS  ================================ -->
+    <!-- =============================================================================== -->
+    <xsd:simpleType name="operatorEnumeration">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The OperatorEnumeration simple type defines acceptable operators. Each
+                operator defines how to evaluate multiple arguments.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="AND"/>
+            <xsd:enumeration value="OR"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- =============================================================================== -->
+    <!-- ==============================  SUPPORTING TYPES  ============================== -->
+    <!-- =============================================================================== -->
+    <xsd:complexType name="TextType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">This type allows the xml:lang attribute to associate a specific language
+                with an element's string content.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="xml:lang"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <!-- =============================================================================== -->
+    <!-- ================================  ID PATTERNS  ================================ -->
+    <!-- =============================================================================== -->
+    <xsd:simpleType name="namePattern">
+        <xsd:union memberTypes="cpe-name:cpe22Type cpe-name:cpe23Type"/>
+    </xsd:simpleType>
+    <!-- ================================================== -->
+    <!-- =====  Change History  -->
+    <!-- ================================================== -->
+    <!--
+        v2.2 - Initial working version
+        v2.3 - Various refactoring of types to use element refs.  This enables more fine-grained reuse of this schema and allows XSD substitution to be possible.
+                Updated the name pattern.
+    -->
+</xsd:schema>

--- a/openscap_report/scap_results_parser/schemas/xccdf/1.2/datatypes.dtd
+++ b/openscap_report/scap_results_parser/schemas/xccdf/1.2/datatypes.dtd
@@ -1,0 +1,203 @@
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
+        Note this DTD is NOT normative, or even definitive. - - the
+        prose copy in the datatypes REC is the definitive version
+        (which shouldn't differ from this one except for this comment
+        and entity expansions, but just in case)
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!--
+        Customisation entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength;">
+<!ENTITY % facet "%ordered; | %unordered;">
+<!ENTITY % facetAttr 
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>

--- a/openscap_report/scap_results_parser/schemas/xccdf/1.2/xccdf_1.2.xsd
+++ b/openscap_report/scap_results_parser/schemas/xccdf/1.2/xccdf_1.2.xsd
@@ -1,0 +1,4076 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:cdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe2="http://cpe.mitre.org/language/2.0"
+    targetNamespace="http://checklists.nist.gov/xccdf/1.2" elementFormDefault="qualified"
+    attributeFormDefault="unqualified" version="1.2.1">
+
+    <xsd:annotation>
+        <xsd:documentation xml:lang="en"> This schema defines the Extensible Configuration Checklist
+            Description Format (XCCDF), a data format for defining security benchmarks and
+            checklists, and for recording the results of applying such benchmarks. For more
+            information, consult the specification document, NIST Interagency Report 7275 Revision
+            4, "Specification for the Extensible Configuration Checklist Description Format Version
+            1.2". This schema was developed by Neal Ziring, with ideas and assistance from David
+            Waltermire. The following helpful individuals also contributed ideas to the definition
+            of this schema: David Proulx, Andrew Buttner, Ryan Wilson, Matthew Kerr, and Stephen
+            Quinn. Ian Crawford found numerous discrepancies between this schema and the spec
+            document. Peter Mell and his colleagues also made many suggestions. </xsd:documentation>
+        <xsd:appinfo>
+            <schema>XCCDF Language</schema>
+            <author>Neal Ziring</author>
+            <version>1.2</version>
+            <date>2012-02-23</date>
+        </xsd:appinfo>
+    </xsd:annotation>
+
+    <!-- Import base XML namespace -->
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../common/xml.xsd">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Import the XML namespace because this schema uses the
+                @xml:lang and @xml:base attributes. </xsd:documentation>
+        </xsd:annotation>
+    </xsd:import>
+
+    <!-- Import CPE 2.3 Language namespace -->
+    <xsd:import namespace="http://cpe.mitre.org/language/2.0" schemaLocation="cpe-language_2.3.xsd">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Import the Common Platform Enumeration language
+                schema, which can be used for defining compound CPE tests for complex IT platforms
+                in the &lt;xccdf:Benchmark&gt;. For more info see NIST IRs 7695-7698, the
+                specification documents for CPE version 2.3. </xsd:documentation>
+        </xsd:annotation>
+    </xsd:import>
+
+    <!-- ************************************************************** -->
+    <!-- *****************  Benchmark Element  ************************ -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Benchmark">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This is the root element of the XCCDF document; it
+                must appear exactly once. It encloses the entire benchmark, and contains both
+                descriptive information and structural information. Note that the order of
+                &lt;xccdf:Group&gt; and &lt;xccdf:Rule&gt; child elements may matter for the
+                appearance of a generated document. &lt;xccdf:Group&gt; and &lt;xccdf:Rule&gt;
+                children may be freely intermingled, but they must appear after any
+                &lt;xccdf:Value&gt; children. All the other children must appear in the order
+                shown.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="cdf:status" minOccurs="1" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Status of the &lt;xccdf:Benchmark&gt;
+                            indicating its level of maturity or consensus. If more than one
+                            &lt;xccdf:status&gt; element appears, the element's @date attribute
+                            should be included.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="dc-status" minOccurs="0" maxOccurs="unbounded"
+                    type="cdf:dc-statusType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Holds additional status information using
+                            the Dublin Core format.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="title" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Title of the &lt;xccdf:Benchmark&gt;; an
+                            &lt;xccdf:Benchmark&gt; should have an
+                            &lt;xccdf:title&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="description" type="cdf:htmlTextWithSubType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Text that describes the
+                            &lt;xccdf:Benchmark&gt;; an &lt;xccdf:Benchmark&gt; should have an
+                            &lt;xccdf:description&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="notice" type="cdf:noticeType" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Legal notices (licensing information, terms
+                            of use, etc.), copyright statements, warnings, and other advisory
+                            notices about this &lt;xccdf:Benchmark&gt; and its
+                            use.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="front-matter" type="cdf:htmlTextWithSubType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Introductory matter for the beginning of
+                            the &lt;xccdf:Benchmark&gt; document; intended for use during Document
+                            Generation.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="rear-matter" type="cdf:htmlTextWithSubType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Concluding material for the end of the
+                            &lt;xccdf:Benchmark&gt; document; intended for use during Document
+                            Generation.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="reference" type="cdf:referenceType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Supporting references for the
+                            &lt;xccdf:Benchmark&gt; document.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="plain-text" type="cdf:plainTextType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Definitions for reusable text blocks, each
+                            with a unique identifier.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="cpe2:platform-specification" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A list of identifiers for complex platform
+                            definitions, written in CPE applicability language format. Authors may
+                            define complex platforms within this element, and then use their locally
+                            unique identifiers anywhere in the &lt;xccdf:Benchmark&gt; element in
+                            place of a CPE name.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="platform" type="cdf:CPE2idrefType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Applicable platforms for this
+                            &lt;xccdf:Benchmark&gt;. Authors should use the element to identify the
+                            systems or products to which the &lt;xccdf:Benchmark&gt;
+                            applies.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="version" type="cdf:versionType" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Version number of the
+                            &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0"
+                    maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">XML metadata for the
+                            &lt;xccdf:Benchmark&gt;. Metadata allows many additional pieces of
+                            information, including authorship, publisher, support, and other similar
+                            details, to be embedded in an
+                            &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="cdf:model" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">URIs of suggested scoring models to be used
+                            when computing a score for this &lt;xccdf:Benchmark&gt;. A suggested
+                            list of scoring models and their URIs is provided in the XCCDF
+                            specification.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="cdf:Profile" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">&lt;xccdf:Profile&gt; elements that
+                            reference and customize sets of items in the
+                            &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="cdf:Value" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Parameter &lt;xccdf:Value&gt; elements that
+                            support &lt;xccdf:Rule&gt; elements and descriptions in the
+                            &lt;xccdf:Benchmark&gt;. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                    <xsd:element ref="cdf:Group">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">&lt;xccdf:Group&gt; elements that
+                                comprise the &lt;xccdf:Benchmark&gt;; each may contain additional
+                                &lt;xccdf:Value&gt;, &lt;xccdf:Rule&gt;, and other
+                                &lt;xccdf:Group&gt; elements. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element ref="cdf:Rule">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">&lt;xccdf:Rule&gt; elements that
+                                comprise the &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:choice>
+                <xsd:element ref="cdf:TestResult" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">&lt;xccdf:Benchmark&gt; test result records
+                            (one per &lt;xccdf:Benchmark&gt; run).</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="signature" type="cdf:signatureType" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A digital signature asserting authorship
+                            and allowing verification of the integrity of the
+                            &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="cdf:benchmarkIdType" use="required">
+                <xsd:annotation>
+                    <xsd:documentation>Unique &lt;xccdf:Benchmark&gt;
+                        identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="Id" type="xsd:ID" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">An identifier used for referencing elements
+                        included in an XML signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="resolved" type="xsd:boolean" default="false" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">True if &lt;xccdf:Benchmark&gt; has already
+                        undergone the resolution process.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="style" type="xsd:string" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Name of an &lt;xccdf:Benchmark&gt; authoring
+                        style or set of conventions or constraints to which this
+                        &lt;xccdf:Benchmark&gt; conforms (e.g., “SCAP 1.2”).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="style-href" type="xsd:anyURI" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">URL of a supplementary stylesheet or schema
+                        extension that can be used to verify conformance to the named
+                        style.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute ref="xml:lang"/>
+        </xsd:complexType>
+
+        <xsd:unique name="noticeIdUnique">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> Legal notices must have unique id values.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="cdf:notice"/>
+            <xsd:field xpath="@id"/>
+        </xsd:unique>
+
+        <xsd:key name="itemIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> Items must have unique id values, and also they
+                    must not collide. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Value|.//cdf:Group|.//cdf:Rule|./cdf:plain-text"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="modelSystemKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> Model system attributes must be unique.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:model"/>
+            <xsd:field xpath="@system"/>
+        </xsd:key>
+
+        <xsd:key name="valueIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:Value&gt; item ids are special keys,
+                    need this for the valueIdKeyRef and valueExtIdKeyRef keyrefs below.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Value"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="groupIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:Group&gt; item ids are special keys,
+                    need this for the groupIdKeyRef keyref below. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Group"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="ruleIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:Rule&gt; items have a unique key, we
+                    need this for the ruleIdKeyRef keyref below. (&lt;xccdf:Rule&gt; key refs are
+                    used by &lt;xccdf:rule-result&gt; elements.) </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Rule"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="selectableItemIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:Group&gt; and &lt;xccdf:Rule&gt; item
+                    ids are special keys, we need this for the requiresIdKeyRef keyref below.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Group | .//cdf:Rule"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="plainTextValueIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:plain-text&gt; objects and
+                    &lt;xccdf:Value&gt; objects each have an id, and they must be unique and not
+                    overlap. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:plain-text | .//cdf:Value"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:key name="profileIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:Profile&gt; objects have a unique id, it
+                    is used for extension, too. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:Profile"/>
+            <xsd:field xpath="@id"/>
+        </xsd:key>
+
+        <xsd:keyref name="valueExtIdKeyRef" refer="cdf:valueIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> An @extends attribute on &lt;xccdf:Value&gt;
+                    object must reference an existing &lt;xccdf:Value&gt;. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Value"/>
+            <xsd:field xpath="@extends"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="groupExtIdKeyRef" refer="cdf:groupIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> An @extends attribute on &lt;xccdf:Group&gt;
+                    objects must reference an existing &lt;xccdf:Group&gt;. NOTE:
+                    &lt;xccdf:Group&gt; extension is now deprecated and should be avoided.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Group"/>
+            <xsd:field xpath="@extends"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="ruleExtIdKeyRef" refer="cdf:ruleIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> An @extends attribute on an &lt;xccdf:Rule&gt;
+                    object must reference an existing &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:Rule"/>
+            <xsd:field xpath="@extends"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="profileExtIdKeyRef" refer="cdf:profileIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> An @extends attribute on &lt;xccdf:Profile&gt;
+                    object must reference an existing &lt;xccdf:Profile&gt;. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:Profile"/>
+            <xsd:field xpath="@extends"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="valueIdKeyRef" refer="cdf:valueIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:check-export&gt; elements must reference
+                    existing &lt;xccdf:Value&gt; elements. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:check/cdf:check-export"/>
+            <xsd:field xpath="@value-id"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="subValueKeyRef" refer="cdf:plainTextValueIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> &lt;xccdf:sub&gt; elements must reference existing
+                    &lt;xccdf:Value&gt; or &lt;xccdf:plain-text&gt; ids. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath=".//cdf:sub"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:keyref>
+
+        <xsd:keyref name="ruleIdKeyRef" refer="cdf:ruleIdKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> The &lt;xccdf:rule-result&gt; element @idref must
+                    refer to an existing &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:TestResult/cdf:rule-result"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:keyref>
+
+    </xsd:element>
+
+    <xsd:complexType name="noticeType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Data type for an &lt;xccdf:notice&gt; element.
+                &lt;xccdf:notice&gt; elements are used to include legal notices (licensing
+                information, terms of use, etc.), copyright statements, warnings, and other advisory
+                notices about this &lt;xccdf:Benchmark&gt; and its use. This information may be
+                expressed using XHTML or may be a simply text expression. Each &lt;xccdf:notice&gt;
+                element must have a unique identifier. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded"
+                processContents="skip"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:NCName">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The unique identifier for this
+                    &lt;xccdf:notice&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute ref="xml:base"/>
+        <xsd:attribute ref="xml:lang"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="dc-statusType">
+        <xsd:annotation>
+            <xsd:documentation>Data type element for the &lt;xccdf:dc-status&gt; element, which
+                holds status information about its parent element using the Dublin Core format,
+                expressed as elements of the DCMI Simple DC Element specification.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any namespace="http://purl.org/dc/elements/1.1/" minOccurs="1" processContents="lax"
+                maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="plainTextType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The data type for an &lt;xccdf:plain-text&gt; element,
+                which is a reusable text block for reference by the &lt;xccdf:sub&gt; element. This
+                allows text to be defined once and then reused multiple times. Each
+                &lt;xccdf:plain-text&gt; element mush have a unique id.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="id" type="xsd:NCName" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The unique identifier for this
+                            &lt;xccdf:plain-text&gt; element.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="referenceType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This element provides supplementary descriptive text
+                for a XCCDF elements. When used, it has either a simple string value or a value
+                consisting of simple Dublin Core elements. If a bare string appears, then it is
+                taken to be the string content for a Dublin Core title element. Multiple
+                &lt;xccdf:reference&gt; elements may appear; a document generation processing tool
+                may concatenate them, or put them into a reference list, and may choose to number
+                them. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any namespace="http://purl.org/dc/elements/1.1/" processContents="lax"
+                minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="href" type="xsd:anyURI">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">A URL pointing to the referenced
+                    resource.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="override" type="xsd:boolean">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Used to manage inheritance
+                    processing.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="signatureType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type of an &lt;XMLDSig:signature&gt; element,
+                which holds an enveloped digital signature asserting authorship and allowing
+                verification of the integrity of associated data (e.g., its parent element, other
+                documents, portions of other documents). </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any namespace="http://www.w3.org/2000/09/xmldsig#" processContents="skip"
+                minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="metadataType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type that supports inclusion of metadata about a
+                document or element. This is particularly useful for facilitating the discovery and
+                retrieval of XCCDF checklists from public repositories. When used, the contents of
+                the &lt;xccdf:metadata&gt; element are expressed in XML. The &lt;xccdf:Benchmark&gt;
+                element's metadata should contain information formatted using the Dublin Core
+                Metadata Initiative (DCMI) Simple DC Element specification, as described in [DCES]
+                and [DCXML]. Benchmark consumers should be prepared to process Dublin Core metadata
+                in the &lt;xccdf:metadata&gt; element. Other metadata schemes, including ad-hoc
+                elements, are also allowed, both in the &lt;xccdf:Benchmark&gt; and in other
+                elements.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any minOccurs="1" maxOccurs="unbounded" processContents="lax" namespace="##other"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- ************************************************************** -->
+    <!-- *************  Global elements and types  ******************** -->
+    <!-- ************************************************************** -->
+    <xsd:element name="status">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The acceptance status of an element with an optional
+                date attribute, which signifies the date of the status change. If an element does
+                not have its own &lt;xccdf:status&gt; element, its status is that of its parent
+                element. If there is more than one &lt;xccdf:status&gt; for a single element, then
+                every instance of the &lt;xccdf:status&gt; element must have a @date attribute, and
+                the &lt;xccdf:status&gt; element with the latest date is considered the current
+                status. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:simpleContent>
+                <xsd:extension base="cdf:statusType">
+                    <xsd:attribute name="date" type="xsd:date" use="optional">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">The date the parent element achieved
+                                the indicated status.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:simpleContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="model">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> A suggested scoring model for an
+                &lt;xccdf:Benchmark&gt;, also encapsulating any parameters needed by the model.
+                Every model is designated with a URI, which appears here as the system attribute.
+                See the XCCDF specification for a list of standard scoring models and their
+                associated URIs. Vendors may define their own scoring models and provide additional
+                URIs to designate them. Some models may need additional parameters; to support such
+                a model, zero or more &lt;xccdf:param&gt; elements may appear as children of the
+                &lt;xccdf:model&gt; element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="param" type="cdf:paramType" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Parameters provided as input to the
+                            designated scoring model.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="system" type="xsd:anyURI" use="required">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A URI designating a scoring
+                        model.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+
+        <xsd:key name="paramNameKey">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en"> Parameter names must be unique.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:selector xpath="./cdf:param"/>
+            <xsd:field xpath="@name"/>
+        </xsd:key>
+    </xsd:element>
+
+    <xsd:complexType name="paramType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for a parameter used in the &lt;xccdf:model&gt;
+                element, which records scoring model information. The contents of this type
+                represent a name-value pair, where the name is recorded in the @name attribute and
+                the value appears in the element body. &lt;xccdf:param&gt; elements with equal
+                values for the @name attribute may not appear as children of the same
+                &lt;xccdf:model&gt; element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:NCName" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The name associated with the contained
+                            value.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+
+    <xsd:simpleType name="statusType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The statusType represents the possible levels of
+                maturity or consensus level for its parent element as recorded by an
+                &lt;xccdf:status&gt; element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="accepted">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Released as final</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="deprecated">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">No longer needed</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="draft">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Released in draft state</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="incomplete">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Under initial development</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="interim">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Revised and in the process of being
+                        finalized</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="versionType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for most &lt;xccdf:version&gt; elements.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="time" type="xsd:dateTime" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The time that this version of the
+                            associated element was completed. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="update" type="xsd:anyURI" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A URI indicating a location where updates
+                            to the associated element may be obtained. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <!-- ************************************************************** -->
+    <!-- ********************  Text Types  **************************** -->
+    <!-- ************************************************************** -->
+    <xsd:complexType name="textType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for a simple text string with an @override
+                attribute for controlling inheritance. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="xml:lang"/>
+                <xsd:attribute name="override" type="xsd:boolean" use="optional" default="0">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Used to manage inheritance.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="htmlTextType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type for a string with optional XHTML elements and
+                an @xml:lang attribute. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded"
+                processContents="skip"/>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:lang"/>
+        <xsd:attribute name="override" type="xsd:boolean" use="optional" default="0">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Used to manage inheritance. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="htmlTextWithSubType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type for a string with optional XHTML elements,
+                and an @xml:lang attribute. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="sub" type="cdf:subType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
+                        &lt;xccdf:plain-text&gt; element to be used for text
+                        substitution</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+        </xsd:choice>
+        <xsd:attribute ref="xml:lang"/>
+        <xsd:attribute name="override" type="xsd:boolean" use="optional" default="0">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Used to manage inheritance. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="profileNoteType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for an &lt;xccdf:profile-note&gt; within an
+                &lt;xccdf:Rule&gt;. This element contains text that describes special aspects of an
+                &lt;xccdf:Rule&gt; relative to one or more &lt;xccdf:Profile&gt; elements. This
+                allows an author to document things within &lt;xccdf:Rule&gt; elements that are
+                specific to a given &lt;xccdf:Profile&gt;. This information might then be displayed
+                to a reader based on the selection of a particular &lt;xccdf:Profile&gt;. The body
+                text may include XHTML mark-up as well as &lt;xccdf:sub&gt; elements.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="sub" type="cdf:subType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
+                        &lt;xccdf:plain-text&gt; element to be used for text
+                        substitution</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+        </xsd:choice>
+        <xsd:attribute ref="xml:lang"/>
+        <xsd:attribute name="tag" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The identifier of this note. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="textWithSubType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for a string with embedded &lt;xccdf:Value&gt;
+                substitutions and an @override attribute to help manage inheritance.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="sub" type="cdf:subType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
+                        &lt;xccdf:plain-text&gt; element to be used for text substitution.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:lang"/>
+        <xsd:attribute name="override" type="xsd:boolean" use="optional" default="0">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Used to manage inheritance. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="subType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The type used for &lt;xccdf:sub&gt; elements. The
+                &lt;xccdf:sub&gt; element identifies replacement content that should appear in place
+                of the &lt;xccdf:sub&gt; element during text substitution. The subType consists of a
+                regular idrefType with an additional @use attribute to dictate the behavior of the
+                &lt;xccdf:sub&gt; element under substitution. When the @idref is to an
+                &lt;xccdf:Value&gt;, the @use attribute indicates whether the &lt;xccdf:Value&gt;
+                element's title or value should replace the &lt;xccdf:sub&gt; element. The @use
+                attribute is ignored when the @idref is to an &lt;xccdf:plain-text&gt; element; the
+                body of the &lt;xccdf:plain-text&gt; element is always used to replace the
+                &lt;xccdf:sub&gt; element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:idrefType">
+                <xsd:attribute name="use" use="optional" default="value" type="cdf:subUseEnumType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Dictates the nature of the content inserted
+                            under text substitution processing. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="benchmarkIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Benchmark&gt; elements. xccdf_N_benchmark_S, where N is a reverse-DNS
+                style namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_benchmark_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="ruleIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Rule&gt; elements. xccdf_N_rule_S, where N is a reverse-DNS style
+                namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_rule_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="groupIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Group&gt; elements. xccdf_N_group_S, where N is a reverse-DNS style
+                namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_group_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="valueIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Value&gt; elements. xccdf_N_value_S, where N is a reverse-DNS style
+                namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_value_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="profileIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Profile&gt; elements. xccdf_N_profile_S, where N is a reverse-DNS style
+                namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_profile_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="testresultIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:TestResult&gt; elements. xccdf_N_testresult_S, where N is a reverse-DNS
+                style namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_testresult_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="tailoringIdType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The format required for the @id property of
+                &lt;xccdf:Tailoring&gt; elements. xccdf_N_tailoring_S, where N is a reverse-DNS
+                style namespace and S is an NCName-compatible string. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NCName">
+            <xsd:pattern value="xccdf_[^_]+_tailoring_.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="idrefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for elements that contain a reference to
+                another XCCDF element </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="idref" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The id value of another XCCDF
+                    element</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="idrefListType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for elements contain list of references to
+                other XCCDF elements </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="idref" type="xsd:NMTOKENS" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">A space-separated list of id values from other
+                    XCCDF elements</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="CPE2idrefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for &lt;xccdf:platform&gt; elements that do
+                not need @override attributes. (I.e., &lt;xccdf:platform&gt; elements that are in
+                structures that cannot be extended, such as &lt;xccdf:TestResult&gt; and
+                &lt;xccdf:Benchmark&gt; elements.) This is used to identify the applicable target
+                platform for its respective parent elements. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="idref" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Should be a CPE 2.3 Applicability Language
+                    identifier using the Formatted String binding or the value of a
+                    &lt;cpe:platform-specification&gt; element's @id attribute, the latter acting as
+                    a reference to some expression defined using the CPE schema in the
+                    &lt;xccdf:Benchmark&gt; element's &lt;cpe:platform-specification&gt; element.
+                    The @idref may be a CPE Applicability Language identifier using the URI binding,
+                    although this is less preferred.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="overrideableCPE2idrefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Data type for &lt;xccdf:platform&gt; elements that need
+                @override attributes. (I.e., &lt;xccdf:platform&gt; elements that are in structures
+                that can be extended, such as Items and &lt;xccdf:Profile&gt; elements.) This is
+                used to identify the applicable target platform for its respective parent elements.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:CPE2idrefType">
+                <xsd:attribute name="override" type="xsd:boolean" use="optional" default="0">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Used to manage inheritance.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+    <!-- ************************************************************** -->
+    <!-- **************** Item Element (Base Class)  ****************** -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Item" type="cdf:itemType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> An item is a named constituent of an
+                &lt;xccdf:Benchmark&gt;. There are three types of items: &lt;xccdf:Group&gt;,
+                &lt;xccdf:Rule&gt; and &lt;xccdf:Value&gt;. The &lt;xccdf:Item&gt; element type
+                imposes constraints shared by all &lt;xccdf:Group&gt;, &lt;xccdf:Rule&gt; and
+                &lt;xccdf:Value&gt; elements. The itemType is abstract, so the element
+                &lt;xccdf:Item&gt; can never appear in a valid XCCDF document.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="itemType" abstract="1">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This abstract itemType represents the basic data
+                shared by all &lt;xccdf:Group&gt;, &lt;xccdf:Rule&gt; and &lt;xccdf:Value&gt;
+                elements. All elements in an itemType are optional, although each element that
+                builds on the itemType may add its own elements, some of which will be required for
+                that element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element ref="cdf:status" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Status of the item and date at which it
+                        attained that status. &lt;xccdf:Benchmark&gt; authors may use this element
+                        to record the maturity or consensus level for elements in the
+                        &lt;xccdf:Benchmark&gt;. If an item does not have an explicit
+                        &lt;xccdf:status&gt; given, then its status is that of its
+                        parent.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dc-status" minOccurs="0" maxOccurs="unbounded"
+                type="cdf:dc-statusType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds additional status information using the
+                        Dublin Core format.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="version" type="cdf:versionType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Version information about this item.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="title" type="cdf:textWithSubType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Title of the item. Every item should have an
+                        &lt;xccdf:title&gt;, because this helps people understand the purpose of the
+                        item. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="description" type="cdf:htmlTextWithSubType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Text that describes the item.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="warning" type="cdf:warningType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A note or caveat about the item intended to
+                        convey important cautionary information for the &lt;xccdf:Benchmark&gt; user
+                        (e.g., “Complying with this rule will cause the system to reject all IP
+                        packets”). If multiple &lt;xccdf:warning&gt; elements appear, benchmark
+                        consumers should concatenate them for generating reports or documents.
+                        Benchmark consumers may present this information in a special manner in
+                        generated documents.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="question" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Interrogative text to present to the user
+                        during tailoring. It may also be included into a generated document. For
+                        &lt;xccdf:Rule&gt; and &lt;xccdf:Group&gt; elements, the
+                        &lt;xccdf:question&gt; text should be a simple binary (yes/no) question
+                        because it is supporting the selection aspect of tailoring. For
+                        &lt;xccdf:Value&gt; elements, the &lt;xccdf:question&gt; should solicit the
+                        user to provide a specific value. Tools may also display constraints on
+                        values and any defaults as specified by the other &lt;xccdf:Value&gt;
+                        properties.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="reference" type="cdf:referenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">References where the user can learn more about
+                        the subject of this item. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">XML metadata associated with this item, such as
+                        sources, special information, or other details. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="abstract" type="xsd:boolean" default="false" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If true, then this item is abstract and exists only
+                    to be extended. The use of this attribute for &lt;xccdf:Group&gt; elements is
+                    deprecated and should be avoided. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="cluster-id" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier to be used as a means to identify
+                    (refer to) related items. It designates membership in a cluster of items, which
+                    are used for controlling items via &lt;xccdf:Profile&gt; elements. All the items
+                    with the same cluster identifier belong to the same cluster. A selector in an
+                    &lt;xccdf:Profile&gt; may refer to a cluster, thus making it easier for authors
+                    to create and maintain &lt;xccdf:Profile&gt; elements in a complex
+                    &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="extends" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The identifier of an item on which to base this
+                    item. If present, it must have a value equal to the @id attribute of another
+                    item. The use of this attribute for &lt;xccdf:Group&gt; elements is deprecated
+                    and should be avoided. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="hidden" type="xsd:boolean" default="false" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If this item should be excluded from any generated
+                    documents although it may still be used during assessments. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="prohibitChanges" type="xsd:boolean" default="false" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If benchmark producers should prohibit changes to
+                    this item during tailoring. An author should use this when they do not want to
+                    allow end users to change the item. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute ref="xml:lang"/>
+        <xsd:attribute ref="xml:base"/>
+        <xsd:attribute name="Id" type="xsd:ID" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier used for referencing elements
+                    included in an XML signature</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+
+    <!-- ************************************************************** -->
+    <!-- ************ Selectable Item Type (Base Class)  ************** -->
+    <!-- ************************************************************** -->
+    <xsd:complexType name="selectableItemType" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This abstract item type represents the basic data
+                shared by all &lt;xccdf:Group&gt; and &lt;xccdf:Rule&gt; elements.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:itemType">
+                <xsd:sequence>
+                    <xsd:element name="rationale" type="cdf:htmlTextWithSubType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Descriptive text giving rationale or
+                                motivations for abiding by this
+                                &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt; (i.e., why it is important to
+                                the security of the target platform).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="platform" type="cdf:overrideableCPE2idrefType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Platforms to which this
+                                &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt; applies.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="requires" type="cdf:idrefListType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">The identifiers of other
+                                &lt;xccdf:Group&gt; or &lt;xccdf:Rule&gt; elements that must be
+                                selected for this &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt; to be
+                                evaluated and scored properly. Each &lt;xccdf:requires&gt; element
+                                specifies a list of one or more required items by their identifiers.
+                                If at least one of the specified &lt;xccdf:Group&gt; or
+                                &lt;xccdf:Rule&gt; elements is selected, the requirement is met.
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="conflicts" type="cdf:idrefType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">The identifier of another
+                                &lt;xccdf:Group&gt; or &lt;xccdf:Rule&gt; that must be unselected
+                                for this &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt; to be evaluated and
+                                scored properly. Each &lt;xccdf:conflicts&gt; element specifies a
+                                single conflicting item using its idref attribute. If the specified
+                                &lt;xccdf:Group&gt; or &lt;xccdf:Rule&gt; element is not selected,
+                                the requirement is met.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="selected" type="xsd:boolean" default="true" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">If true, this
+                            &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt; is selected to be processed as
+                            part of the &lt;xccdf:Benchmark&gt; when it is applied to a target
+                            system. An unselected &lt;xccdf:Group&gt; does not get processed, and
+                            its contents are not processed either (i.e., all descendants of an
+                            unselected &lt;xccdf:Group&gt; are implicitly unselected). An unselected
+                            &lt;xccdf:Rule&gt; is not checked and does not contribute to scoring.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="weight" type="cdf:weightType" default="1.0" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The relative scoring weight of this
+                            &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt;, for computing a score, expressed
+                            as a non-negative real number. It denotes the importance of an
+                            &lt;xccdf:Group&gt;/&lt;xccdf:Rule&gt;. Under some scoring models,
+                            scoring is computed independently for each collection of sibling
+                            &lt;xccdf:Group&gt; and &lt;xccdf:Rule&gt; elements, then normalized as
+                            part of the overall scoring process.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- ************************************************************** -->
+    <!-- **********************  Group Element  *********************** -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Group" type="cdf:groupType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">An item that can hold other items. It allows an author
+                to collect related items into a common structure and provide descriptive text and
+                references about them.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="groupType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:Group&gt; element. A
+                &lt;xccdf:Group&gt; element contains descriptive information about a portion of an
+                &lt;xccdf:Benchmark&gt;, as well as &lt;xccdf:Rule&gt;, &lt;xccdf:Value&gt;, and/or
+                other &lt;xccdf:Group&gt; elements</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:selectableItemType">
+                <xsd:sequence>
+                    <xsd:element ref="cdf:Value" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">&lt;xccdf:Value&gt; elements that
+                                belong to this &lt;xccdf:Group&gt;. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element ref="cdf:Group">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">Sub-&lt;xccdf:Groups&gt; under this
+                                    &lt;xccdf:Group&gt;. </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element ref="cdf:Rule">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">&lt;xccdf:Rule&gt; elements that
+                                    belong to this &lt;xccdf:Group&gt;. </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:choice>
+                    <xsd:element name="signature" type="cdf:signatureType" minOccurs="0"
+                        maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A digital signature asserting
+                                authorship and allowing verification of the integrity of the
+                                &lt;xccdf:Group&gt;. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="id" type="cdf:groupIdType" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Unique element identifier; used by other
+                            elements to refer to this element. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+    <!-- ************************************************************** -->
+    <!-- ********************  Rule Element  ************************** -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Rule" type="cdf:ruleType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The &lt;xccdf:Rule&gt; element contains the
+                description for a single item of guidance or constraint. &lt;xccdf:Rule&gt; elements
+                form the basis for testing a target platform for compliance with an
+                &lt;xccdf:Benchmark&gt;, for scoring, and for conveying descriptive prose,
+                identifiers, references, and remediation information. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:unique name="ruleCheckSelectorKey">
+            <xsd:selector xpath="./cdf:check"/>
+            <xsd:field xpath="@selector"/>
+            <xsd:field xpath="@system"/>
+        </xsd:unique>
+        <xsd:unique name="ruleCheckIdKey">
+            <xsd:selector xpath=".//cdf:check"/>
+            <xsd:field xpath="@id"/>
+        </xsd:unique>
+    </xsd:element>
+
+    <xsd:complexType name="ruleType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:Rule&gt; element that
+                represents a specific &lt;xccdf:Benchmark&gt; test. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:selectableItemType">
+                <xsd:sequence>
+                    <xsd:element name="ident" type="cdf:identType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A globally meaningful identifier for
+                                this &lt;xccdf:Rule&gt;. This may be the name or identifier of a
+                                security configuration issue or vulnerability that the
+                                &lt;xccdf:Rule&gt; assesses.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="impact-metric" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">The potential impact of failure to
+                                conform to the &lt;xccdf:Rule&gt;, expressed as a CVSS 2.0 base
+                                vector. </xsd:documentation>
+                            <xsd:appinfo>
+                                <deprecated_info>
+                                    <version>1.2</version>
+                                    <reason>The &lt;xccdf:impact-metric&gt; property was found to be
+                                        of little use in the anticipated XCCDF use-cases.</reason>
+                                    <comment>While there is no direct replacement for this property,
+                                        authors seeking to include equivalent information can use an
+                                        &lt;xccdf:Rule&gt; element's &lt;xccdf:metadata&gt; property
+                                        to hold this information.</comment>
+                                </deprecated_info>
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="profile-note" minOccurs="0" type="cdf:profileNoteType"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Text that describes special aspects of
+                                the &lt;xccdf:Rule&gt; related to one or more &lt;xccdf:Profile&gt;
+                                elements. This allows an author to document things within
+                                &lt;xccdf:Rule&gt; elements that are specific to a given
+                                &lt;xccdf:Profile&gt;, and then select the appropriate text based on
+                                the selected &lt;xccdf:Profile&gt; and display it to the
+                                reader.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="fixtext" type="cdf:fixTextType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Data that describes how to bring a
+                                target system into compliance with this
+                                &lt;xccdf:Rule&gt;.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="fix" type="cdf:fixType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A command string, script, or other
+                                system modification statement that, if executed on the target
+                                system, can bring it into full, or at least better, compliance with
+                                this &lt;xccdf:Rule&gt;.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:choice>
+                        <xsd:element name="check" type="cdf:checkType" minOccurs="0"
+                            maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">The definition of, or a reference
+                                    to, the target system check needed to test compliance with this
+                                    &lt;xccdf:Rule&gt;. Sibling &lt;xccdf:check&gt; elements must
+                                    have different values for the combination of their @selector and
+                                    @system attributes, and must have different values for their @id
+                                    attribute (if any).</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complex-check" minOccurs="0" type="cdf:complexCheckType"
+                            maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">A boolean expression composed of
+                                    operators (and, or, not) and individual
+                                    checks.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:choice>
+                    <xsd:element name="signature" type="cdf:signatureType" minOccurs="0"
+                        maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A digital signature asserting
+                                authorship and allowing verification of the integrity of the
+                                &lt;xccdf:Rule&gt;.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="id" type="cdf:ruleIdType" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Unique element identifier used by other
+                            elements to refer to this element.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="role" type="cdf:roleEnumType" use="optional" default="full">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; element’s role in
+                            scoring and reporting.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="severity" type="cdf:severityEnumType" default="unknown"
+                    use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Severity level code to be used for metrics
+                            and tracking.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="multiple" type="xsd:boolean" use="optional" default="false">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Applicable in cases where there are
+                            multiple instances of a target. For example, an &lt;xccdf:Rule&gt; may
+                            provide a recommendation about the configuration of application user
+                            accounts, but an application may have many user accounts. Each account
+                            would be considered an instance of the broader assessment target of user
+                            accounts. If the @multiple attribute is set to true, each instance of
+                            the target to which the &lt;xccdf:Rule&gt; can apply should be tested
+                            separately and the results should be recorded separately. If @multiple
+                            is set to false, the test results of such instances should be combined.
+                            If the checking system does not combine these results automatically, the
+                            results of each instance should be ANDed together to produce a single
+                            result. If the benchmark consumer cannot perform multiple instantiation,
+                            or if multiple instantiation of the &lt;xccdf:Rule&gt; is not applicable
+                            for the target system, then the benchmark consumer may ignore this
+                            attribute.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+    <!-- ************************************************************** -->
+    <!-- *****************  Rule-related Types ************************ -->
+    <!-- ************************************************************** -->
+    <xsd:complexType name="identType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:ident&gt; element, a
+                globally meaningful identifier for an &lt;xccdf:Rule&gt;. The body of
+                &lt;xccdf:ident&gt; element is the name or identifier of a security configuration
+                issue or vulnerability that the &lt;xccdf:Rule&gt; addresses. It has an associated
+                URI that denotes the organization or naming scheme that assigned the name. By
+                setting an &lt;xccdf:ident&gt; element on an &lt;xccdf:Rule&gt;, the
+                &lt;xccdf:Benchmark&gt; author effectively declares that the &lt;xccdf:Rule&gt;
+                instantiates, implements, or remediates the issue for which the name was assigned.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="system" type="xsd:anyURI" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Denotes the organization or naming scheme
+                            that assigned the identifier. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:anyAttribute namespace="##other" processContents="lax">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">May also have other attributes from other
+                            namespaces in order to provide additional metadata for the given
+                            identifier. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:anyAttribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="warningType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:warning&gt; element under
+                the &lt;xccdf:Rule&gt; element. This element holds a note or caveat about the item
+                intended to convey important cautionary information for the &lt;xccdf:Benchmark&gt;
+                user. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:htmlTextWithSubType">
+                <xsd:attribute name="category" type="cdf:warningCategoryEnumType" use="optional"
+                    default="general">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A hint as to the nature of the
+                            warning.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="warningCategoryEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Allowed warning category keywords for the
+                &lt;xccdf:warning&gt; element used in &lt;xccdf:Rule&gt; elements.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="general">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Broad or general-purpose warning
+                        (default)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="functionality">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about possible impacts to functionality
+                        or operational features</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="performance">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about changes to target system
+                        performance or throughput</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="hardware">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about hardware restrictions or possible
+                        impacts to hardware</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="legal">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about legal
+                        implications</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="regulatory">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about regulatory obligations or
+                        compliance implications</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="management">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about impacts to the management or
+                        administration of the target system</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="audit">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about impacts to audit or
+                        logging</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="dependency">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Warning about dependencies between this element
+                        and other parts of the target system, or version
+                        dependencies</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:complexType name="fixTextType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fixtext&gt; element, which
+                contains data that describes how to bring a target system into compliance with an
+                &lt;xccdf:Rule&gt;. Each &lt;xccdf:fixtext&gt; element may be associated with one or
+                more &lt;xccdf:fix&gt; elements through the @fixref attribute. The body holds
+                explanatory text about the fix procedures.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:htmlTextWithSubType">
+                <xsd:attribute name="fixref" type="xsd:NCName" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A reference to the @id of an
+                            &lt;xccdf:fix&gt; element. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="reboot" type="xsd:boolean" use="optional" default="0">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">True if a reboot is known to be required
+                            and false otherwise. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="strategy" type="cdf:fixStrategyEnumType" use="optional"
+                    default="unknown">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The method or approach for making the
+                            described fix. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="disruption" type="cdf:ratingEnumType" use="optional"
+                    default="unknown">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">An estimate of the potential for disruption
+                            or operational degradation that the application of this fix will impose
+                            on the target. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="complexity" type="cdf:ratingEnumType" use="optional"
+                    default="unknown">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The estimated complexity or difficulty of
+                            applying the fix to the target. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="fixType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fix&gt; element. The body
+                of this element contains a command string, script, or other system modification
+                statement that, if executed on the target system, can bring it into full, or at
+                least better, compliance with this &lt;xccdf:Rule&gt;. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="sub" type="cdf:subType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
+                        &lt;xccdf:plain-text&gt; element to be used for text substitution
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="instance" type="cdf:instanceFixType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Designates a spot where the name of the
+                        instance should be substituted into the fix template to generate the final
+                        fix data. If the @context attribute is omitted, the value of the @context
+                        defaults to “undefined”.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="id" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">A local identifier for the element. It is optional
+                    for the @id to be unique; multiple &lt;xccdf:fix&gt; elements may have the same
+                    @id but different values for their other attributes. It is used primarily to
+                    allow &lt;xccdf:fixtext&gt; elements to be associated with one or more
+                    &lt;xccdf:fix&gt; elements </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="reboot" type="xsd:boolean" use="optional" default="0">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">True if a reboot is known to be required and false
+                    otherwise. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="strategy" type="cdf:fixStrategyEnumType" use="optional"
+            default="unknown">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The method or approach for making the described
+                    fix. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="disruption" type="cdf:ratingEnumType" use="optional" default="unknown">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An estimate of the potential for disruption or
+                    operational degradation that the application of this fix will impose on the
+                    target. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="complexity" type="cdf:ratingEnumType" use="optional" default="unknown">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The estimated complexity or difficulty of applying
+                    the fix to the target. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="system" type="xsd:anyURI" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">A URI that identifies the scheme, language, engine,
+                    or process for which the fix contents are written. Table 17 in the XCCDF
+                    specification defines several general-purpose URNs that may be used for this,
+                    and tool vendors and system providers may define and use target-specific
+                    URNs.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="platform" type="xsd:anyURI" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">In case different fix scripts or procedures are
+                    required for different target platform types (e.g., different patches for
+                    Windows Vista and Windows 7), this attribute allows a CPE name or CPE
+                    applicability language expression to be associated with an &lt;xccdf:fix&gt;
+                    element. This should appear on an &lt;xccdf:fix&gt; when the content applies to
+                    only one platform out of several to which the &lt;xccdf:Rule&gt; could apply.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:simpleType name="fixStrategyEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Allowed @strategy keyword values for an
+                &lt;xccdf:Rule&gt; element's &lt;xccdf:fix&gt; or &lt;xccdf:fixtext&gt; elements.
+                The values indicate the method or approach for fixing non-compliance with a
+                particular &lt;xccdf:Rule&gt;. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="unknown">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Strategy not defined
+                        (default)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="configure">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Adjust target
+                        configuration/settings</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="combination">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Combination of two or more
+                        approaches</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="disable">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Turn off or uninstall a target component
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="enable">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Turn on or install a target
+                        component</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="patch">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Apply a patch, hotfix, update,
+                        etc.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="policy">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Remediation requires out-of-band adjustments to
+                        policies or procedures</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="restrict">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Adjust permissions, access rights, filters, or
+                        other access restrictions</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="update">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Install, upgrade or update the
+                        system</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="ratingEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This type enumerates allowed rating values the
+                disruption and complexity properties of an &lt;xccdf:Rule&gt; element's
+                &lt;xccdf:fix&gt; or &lt;xccdf:fixtext&gt; elements. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="unknown">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Rating unknown or impossible to estimate
+                        (default)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="low">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Little or no potential for disruption, very
+                        modest complexity</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="medium">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Some chance of minor disruption, substantial
+                        complexity</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="high">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Likely to cause serious disruption, very
+                        complex</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="instanceFixType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for an &lt;xccdf:instance&gt; element which may
+                appear in an &lt;xccdf:fix&gt; element. The &lt;xccdf:instance&gt; element inside an
+                &lt;xccdf:fix&gt; element designates a spot where the name of the instance should be
+                substituted into the fix template to generate the final fix data.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="context" type="xsd:string" default="undefined" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Describes the scope or significance of the instance
+                    content. The context attribute is intended to be informative and does not affect
+                    basic processing. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="complexCheckType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type for an element that contains a boolean
+                combination of &lt;xccdf:checks&gt;. This element can have only
+                &lt;xccdf:complex-check&gt; and &lt;xccdf:check&gt; elements as children. Child
+                elements may appear in any order but at least one child element must be present. It
+                has two attributes, @operator and @negate, which dictate how &lt;xccdf:check&gt; or
+                &lt;xccdf:complex-check&gt; child elements are to be combined. Truth tables for
+                these operations appear below. </xsd:documentation>
+            <xsd:appinfo>
+                <evaluation_documentation>The two axes represent a pairwise combination of results.
+                    Order of evaluation will not matter. Possible results are abbreviated as
+                    follows: P = Pass, F = Fail, U = Unknown, E = Error, N = Not Applicable, K = Not
+                    Checked, S = Not Selected, I = Informational. </evaluation_documentation>
+                <evaluation_chart xml:space="preserve">
+   AND             || P | F | U | E | N | K | S | I ||
+-------------------||-------------------------------||
+          Pass (P) || P | F | U | E | P | P | P | P ||
+          Fail (F) || F | F | F | F | F | F | F | F ||
+       Unknown (U) || U | F | U | U | U | U | U | U ||
+         Error (E) || E | F | U | E | E | E | E | E || 
+ Notapplicable (N) || P | F | U | E | N | N | N | N ||
+    Notchecked (K) || P | F | U | E | N | K | K | K ||
+   Notselected (S) || P | F | U | E | N | K | S | S || 
+ Informational (I) || P | F | U | E | N | K | S | I ||
+------------------------------------------------------ </evaluation_chart>
+                <evaluation_chart xml:space="preserve">
+    OR             || P | F | U | E | N | K | S | I ||
+-------------------||-------------------------------||
+          Pass (P) || P | P | P | P | P | P | P | P ||
+          Fail (F) || P | F | U | E | F | F | F | F ||
+       Unknown (U) || P | U | U | U | U | U | U | U ||
+         Error (E) || P | E | U | E | E | E | E | E || 
+ Notapplicable (N) || P | F | U | E | N | N | N | N ||
+    Notchecked (K) || P | F | U | E | N | K | K | K ||
+   Notselected (S) || P | F | U | E | N | K | S | S || 
+ Informational (I) || P | F | U | E | N | K | S | I ||
+------------------------------------------------------ </evaluation_chart>
+                <evaluation_chart xml:space="preserve">
+NOT || P | F | U | E | N | K | S | I ||
+----||-------------------------------||
+    || F | P | U | E | N | K | S | I ||
+---------------------------------------</evaluation_chart>
+            </xsd:appinfo>
+
+        </xsd:annotation>
+        <xsd:choice minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="check" type="cdf:checkType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Instructions for a single
+                        test.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="complex-check" type="cdf:complexCheckType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A child &lt;xccdf:complex-check&gt;, allowing
+                        another level of logic in combining component checks.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="operator" type="cdf:ccOperatorEnumType" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Indicates whether the child &lt;xccdf:check&gt;
+                    and/or &lt;xccdf:complex-check&gt; elements of this &lt;xccdf:complex-check&gt;
+                    should be combined using an AND or OR operation </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="negate" default="0" type="xsd:boolean" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If true, negate the final result of this
+                    &lt;xccdf:complex-check&gt; after the child elements are combined using the
+                    identified operator.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:simpleType name="ccOperatorEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type for the allowed @operator names for the
+                &lt;xccdf:complex-check&gt; operator attribute. Only AND and OR operators are
+                supported. (The &lt;xccdf:complex-check&gt; has a separate mechanism for negation.)
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="OR">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The logical OR of the component terms
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="AND">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The logical AND of the component
+                        terms</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="checkType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:check&gt; element. The
+                &lt;xccdf:check&gt; element identifies instructions for tests to determine
+                compliance with the &lt;xccdf:Rule&gt; as well as parameters controlling the
+                reporting of those test results. The &lt;xccdf:check&gt; element must have at least
+                one child element. </xsd:documentation>
+            <xsd:appinfo>
+                <evaluation_documentation>The two axes represent a pairwise combination of results.
+                    Order of evaluation will not matter. Possible results are abbreviated as
+                    follows: P = Pass, F = Fail, U = Unknown, E = Error, N = Not Applicable, K = Not
+                    Checked, S = Not Selected, I = Informational. </evaluation_documentation>
+                <evaluation_chart xml:space="preserve">
+   AND             || P | F | U | E | N | K | S | I ||
+-------------------||-------------------------------||
+          Pass (P) || P | F | U | E | P | P | P | P ||
+          Fail (F) || F | F | F | F | F | F | F | F ||
+       Unknown (U) || U | F | U | U | U | U | U | U ||
+         Error (E) || E | F | U | E | E | E | E | E || 
+ Notapplicable (N) || P | F | U | E | N | N | N | N ||
+    Notchecked (K) || P | F | U | E | N | K | K | K ||
+   Notselected (S) || P | F | U | E | N | K | S | S || 
+ Informational (I) || P | F | U | E | N | K | S | I ||
+------------------------------------------------------</evaluation_chart>
+                <evaluation_chart xml:space="preserve">
+NOT || P | F | U | E | N | K | S | I ||
+----||-------------------------------||
+    || F | P | U | E | N | K | S | I ||
+---------------------------------------</evaluation_chart>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="check-import" type="cdf:checkImportType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Identifies a value to be retrieved from the
+                        checking system during testing of a target system. This element's body must
+                        be empty within an &lt;xccdf:check&gt;. After the associated check results
+                        have been collected, the result structure returned by the checking engine is
+                        processed to collect the named information. This information is then
+                        recorded in the check-import element in the corresponding
+                        &lt;xccdf:rule-result&gt;.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="check-export" type="cdf:checkExportType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A mapping from an &lt;xccdf:Value&gt; element
+                        to a checking system variable (i.e., external name or id for use by the
+                        checking system). This supports export of tailoring values from the XCCDF
+                        processing environment to the checking system.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="check-content-ref" minOccurs="0" maxOccurs="unbounded"
+                type="cdf:checkContentRefType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Points to code for a detached check in another
+                        location that uses the language or system specified by the
+                        &lt;xccdf:check&gt; element’s @system attribute. If multiple
+                        &lt;xccdf:check-content-ref&gt; elements appear, they represent alternative
+                        locations from which a benchmark consumer may obtain the check content.
+                        Benchmark consumers should process the alternatives in the order in which
+                        they appear in the XML. The first &lt;xccdf:check-content-ref&gt; from which
+                        content can be successfully retrieved should be used.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="check-content" minOccurs="0" maxOccurs="1"
+                type="cdf:checkContentType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds the actual code of a check, in the
+                        language or system specified by the &lt;xccdf:check&gt; element’s @system
+                        attribute. If both &lt;xccdf:check-content-ref&gt; and
+                        &lt;xccdf:check-content&gt; elements appear in a single &lt;xccdf:check&gt;
+                        element, benchmark consumers should use the &lt;xccdf:check-content&gt;
+                        element only if none of the references can be resolved to provide
+                        content.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="system" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The URI for a checking system. If the checking
+                    system uses XML namespaces, then the system attribute for the system should be
+                    its namespace. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="negate" type="xsd:boolean" use="optional" default="false">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If set to true, the final result of the
+                    &lt;xccdf:check&gt; is negated according to the truth table given below.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="id" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Unique identifier for this element. Optional, but
+                    must be globally unique if present.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="selector" default="" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">This may be referenced from &lt;xccdf:Profile&gt;
+                    selection elements or used during manual tailoring to refine the application of
+                    the &lt;xccdf:Rule&gt;. If no selector values are specified for a given
+                    &lt;xccdf:Rule&gt; by &lt;xccdf:Profile&gt; elements or manual tailoring, all
+                    &lt;xccdf:check&gt; elements with non-empty @selector attributes are ignored. If
+                    an &lt;xccdf:Rule&gt; has multiple &lt;xccdf:check&gt; elements with the same
+                    @selector attribute, each must employ a different checking system, as identified
+                    by the @system attribute of the &lt;xccdf:check&gt; element.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="multi-check" type="xsd:boolean" use="optional" default="false">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Applicable in cases where multiple checks are
+                    executed to determine compliance with a single &lt;xccdf:Rule&gt;. This
+                    situation can arise when an &lt;xccdf:check&gt; includes an
+                    &lt;xccdf:check-content-ref&gt; element that does not include a @name attribute.
+                    The default behavior of a nameless &lt;xccdf:check-content-ref&gt; is to execute
+                    all checks in the referenced check content location and AND their results
+                    together into a single &lt;xccdf:rule-result&gt; using the AND truth table
+                    below. This corresponds to a @multi-check attribute value of “false”. If,
+                    however, the @multi-check attribute is set to "true" and a nameless
+                    &lt;xccdf:check-content-ref&gt; is used, the &lt;xccdf:Rule&gt; produces a
+                    separate &lt;xccdf:rule-result&gt; for each check.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute ref="xml:base"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="checkImportType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:check-import&gt; element,
+                which specifies a value that the &lt;xccdf:Benchmark&gt; author wishes to retrieve
+                from the checking system during testing of a target system. The @import-name
+                attribute identifies some structure in the checking system that is then retrieved.
+                The mapping from the values of this attribute to specific checking system structures
+                is beyond the scope of the XCCDF specification. When the &lt;xccdf:check-import&gt;
+                element appears in the context of an &lt;xccdf:Rule&gt;, then it should be empty and
+                any content must be ignored. When the &lt;xccdf:check-import&gt; element appears in
+                the context of an &lt;xccdf:rule-result&gt;, then its body holds the imported value.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any processContents="skip" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="import-name" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier indicating some structure in the
+                    checking system to be collected. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="import-xpath" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An XPath that is used to select specific values or
+                    structures from the imported structure. This allows further refinement of the
+                    collected data if the imported value takes the form of XML structures.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="checkExportType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:check-export&gt; element,
+                which specifies a mapping from an &lt;xccdf:Value&gt; element to a checking system
+                variable (i.e., external name or id for use by the checking system). This supports
+                export of tailoring &lt;xccdf:Value&gt; elements from the XCCDF processing
+                environment to the checking system. The interface between the XCCDF benchmark
+                consumer and the checking system should support, at a minimum, passing the
+                &lt;xccdf:value&gt; property of the &lt;xccdf:Value&gt; element, but may also
+                support passing the &lt;xccdf:Value&gt; element's @type and @operator
+                properties.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="value-id" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The id of the &lt;xccdf:Value&gt; element to
+                    export. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="export-name" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier indicating some structure in the
+                    checking system into which the identified &lt;xccdf:Value&gt; element's
+                    properties will be mapped. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="checkContentRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:check-content-ref&gt;
+                element, which points to the code for a detached check in another file. This element
+                has no body, just a couple of attributes: @href and @name. The @name is optional, if
+                it does not appear then this reference is to the entire document.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="href" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Identifies the referenced document containing
+                    checking instructions. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="name" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Identifies a particular part or element of the
+                    referenced check document. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="checkContentType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:check-content&gt; element.
+                The body of this element holds the actual code of a check, in the language or system
+                specified by the &lt;xccdf:check&gt; element’s @system attribute. The body of this
+                element may be any XML, but cannot contain any XCCDF elements. XCCDF tools do not
+                process its content directly but instead pass the content directly to checking
+                engines. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:any namespace="##other" processContents="skip"/>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:simpleType name="weightType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for an &lt;xccdf:Rule&gt; element's weight,
+                a non-negative real number. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:decimal">
+            <xsd:minInclusive value="0.0"/>
+            <xsd:totalDigits value="3"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- ************************************************************** -->
+    <!-- *******************  Value Element  ************************** -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Value" type="cdf:valueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The &lt;xccdf:Value&gt; element is a named parameter
+                that can be substituted into properties of other elements within the
+                &lt;xccdf:Benchmark&gt;, including the interior of structured check specifications
+                and fix scripts.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:unique name="valueSelectorKey">
+            <xsd:selector xpath="./cdf:value|cdf:complex-value"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+        <xsd:unique name="defaultSelectorKey">
+            <xsd:selector xpath="./cdf:default|cdf:complex-default"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+        <xsd:unique name="matchSelectorKey">
+            <xsd:selector xpath="./cdf:match"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+        <xsd:unique name="lower-boundSelectorKey">
+            <xsd:selector xpath="./cdf:lower-bound"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+        <xsd:unique name="upper-boundSelectorKey">
+            <xsd:selector xpath="./cdf:upper-bound"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+        <xsd:unique name="choicesSelectorKey">
+            <xsd:selector xpath="./cdf:choices"/>
+            <xsd:field xpath="@selector"/>
+        </xsd:unique>
+    </xsd:element>
+
+    <xsd:complexType name="valueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:Value&gt; element, which
+                is a named parameter that can be substituted into properties of other elements
+                within the &lt;xccdf:Benchmark&gt;, including the interior of structured check
+                specifications and fix scripts. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:itemType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+                        <xsd:element name="value" type="cdf:selStringType" minOccurs="1"
+                            maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">A simple (number, string, or
+                                    boolean) value associated with this &lt;xccdf:Value&gt;. At any
+                                    time an &lt;xccdf:Value&gt; has one active (simple or complex)
+                                    value. If a selector value has been provided under
+                                    &lt;xccdf:Profile&gt; selection or tailoring then the active
+                                    &lt;xccdf:value&gt;/&lt;xccdf:complex-value&gt; is the one with
+                                    a matching @selector. If there is no provided selector or if the
+                                    provided selector does not match the @selector attribute of any
+                                    &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt;, the active
+                                    &lt;xccdf:value&gt;/&lt;xccdf:complex-value&gt; is the one with
+                                    an empty or absent @selector or, failing that, the first
+                                    &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt; in the XML.
+                                    When an &lt;xccdf:Value&gt; is exported or used in text
+                                    substitution, it is the currently active &lt;xccdf:value&gt; or
+                                    &lt;xccdf:complex-value&gt; that is actually used. If there are
+                                    multiple &lt;xccdf:value&gt; and/or &lt;xccdf:complex-value&gt;
+                                    elements, only one may omit a @selector attribute and no two may
+                                    have the same @selector value.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complex-value" type="cdf:selComplexValueType"
+                            minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">A complex (list) value associated
+                                    with this &lt;xccdf:Value&gt;. See the description of the
+                                    &lt;xccdf:value&gt; property for &lt;xccdf:Rule&gt; elements
+                                    regarding activation of an &lt;xccdf:complex-value&gt;.
+                                </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:choice>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="default" type="cdf:selStringType" minOccurs="1"
+                            maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">The default value displayed to the
+                                    user as a suggestion by benchmark producers during tailoring of
+                                    this &lt;xccdf:Value&gt; element. (This is not the default value
+                                    of an &lt;xccdf:Value&gt;; it is just the default display.) If
+                                    there are multiple &lt;xccdf:default&gt; and/or
+                                    &lt;xccdf:complex-default&gt; elements, only one may omit a
+                                    @selector attribute and no two may have the same @selector
+                                    value. </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="complex-default" type="cdf:selComplexValueType"
+                            minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation xml:lang="en">The default
+                                    &lt;xccdf:complex-value&gt; displayed to the user as a
+                                    suggestion by benchmark producers during tailoring of this
+                                    &lt;xccdf:Value&gt; element. (This is not the default value of
+                                    an &lt;xccdf:Value&gt;; it is just the default display.) If
+                                    there are multiple &lt;xccdf:default&gt; and
+                                    &lt;xccdf:complex-default&gt; elements, only one may omit a
+                                    @selector attribute and no two may have the same @selector
+                                    value. </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:choice>
+                    <xsd:element name="match" type="cdf:selStringType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A Perl Compatible Regular Expression
+                                that a benchmark producer may apply during tailoring to validate a
+                                user’s input for the &lt;xccdf:Value&gt;. It uses implicit
+                                anchoring. It applies only when the @type property is “string” or
+                                “number” or a list of strings and/or numbers.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="lower-bound" type="cdf:selNumType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Minimum legal value for this
+                                &lt;xccdf:Value&gt;. It is used to constrain value input during
+                                tailoring, when the @type property is “number”. Values supplied by
+                                the user for tailoring the &lt;xccdf:Benchmark&gt; must be equal to
+                                or greater than this number. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="upper-bound" type="cdf:selNumType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">Maximum legal value for this
+                                &lt;xccdf:Value&gt;. It is used to constrain value input during
+                                tailoring, when the @type is “number”. Values supplied by the user
+                                for tailoring the &lt;xccdf:Benchmark&gt; must be less than or equal
+                                to than this number. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="choices" type="cdf:selChoicesType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A list of legal or suggested choices
+                                (values) for an &lt;xccdf:Value&gt; element, to be used during
+                                tailoring and document generation. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="source" type="cdf:uriRefType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">URI indicating where the tool may
+                                acquire values, value bounds, or value choices for this
+                                &lt;xccdf:Value&gt; element. XCCDF does not attach any meaning to
+                                the URI; it may be an arbitrary community or tool-specific value, or
+                                a pointer directly to a resource. If several instances of the
+                                &lt;xccdf:source&gt; property appear, then they represent
+                                alternative means or locations for obtaining the value in descending
+                                order of preference (i.e., most preferred first).
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="signature" type="cdf:signatureType" minOccurs="0"
+                        maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation xml:lang="en">A digital signature asserting
+                                authorship and allowing verification of the integrity of the
+                                &lt;xccdf:Value&gt;. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="id" type="cdf:valueIdType" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The unique identifier for this element.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="type" type="cdf:valueTypeType" default="string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The data type of the &lt;xccdf:Value&gt;. A
+                            tool may choose any convenient form to store an &lt;xccdf:Value&gt;
+                            element’s &lt;xccdf:value&gt; element, but the @type attribute conveys
+                            how the &lt;xccdf:Value&gt; should be treated for user input validation
+                            purposes during tailoring processing. The @type attribute may also be
+                            used to give additional guidance to the user or to validate the user’s
+                            input. In the case of a list of values, the @type attribute, if present,
+                            applies to all elements of the list individually.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="operator" type="cdf:valueOperatorType" default="equals"
+                    use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The operator to be used for comparing this
+                            &lt;xccdf:Value&gt; to some part of the test system’s configuration
+                            during &lt;xccdf:Rule&gt; checking. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="interactive" type="xsd:boolean" default="0" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Whether tailoring for this
+                            &lt;xccdf:Value&gt; should be performed during &lt;xccdf:Benchmark&gt;
+                            application. The benchmark consumer may ignore the attribute if asking
+                            the user is not feasible or not supported.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="interfaceHint" use="optional" type="cdf:interfaceHintType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A hint or recommendation to a benchmark
+                            consumer or producer about how the user might select or adjust the
+                            &lt;xccdf:Value&gt;. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+    <!-- ************************************************************** -->
+    <!-- ***************  Value-related Types  ************************ -->
+    <!-- ************************************************************** -->
+    <xsd:complexType name="complexValueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Data type that supports values that are lists of simple
+                types. Each element in the list is represented by an instance of the
+                &lt;xccdf:item&gt; child element. If there are no &lt;xccdf:item&gt; child elements
+                then this represents an empty list. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="item" minOccurs="0" maxOccurs="unbounded" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A single item in the list of values.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="selComplexValueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type that supports values that are lists of
+                simple types with an associated @selector attribute used in tailoring.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:complexValueType">
+                <xsd:attribute name="selector" default="" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">This may be referenced from
+                            &lt;xccdf:Profile&gt; selection elements or used during manual tailoring
+                            to refine the application of this property. If no selectors are
+                            specified for a given item by &lt;xccdf:Profile&gt; elements or manual
+                            tailoring, properties with empty or non-existent @selector attributes
+                            are activated. If a selector is applied that does not match the
+                            @selector attribute of any of a given type of property, then no
+                            &lt;xccdf:choices&gt; element is considered activated. The only
+                            exception is the &lt;xccdf:value&gt; and &lt;xccdf:complex-value&gt;
+                            properties of an &lt;xccdf:Value&gt; element - if there is no
+                            &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt; property with a
+                            matching @selector value then the
+                            &lt;xccdf:value&gt;/&lt;xccdf:complex-value&gt; property with an empty
+                            or absent @selector attribute becomes active. If there is no such
+                            &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt;, then the first
+                            &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt; listed becomes
+                            active. This reflects the fact that all &lt;xccdf:Value&gt; elements
+                            require an active value property at all times.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="selChoicesType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> The type of the &lt;xccdf:choice&gt; element, which
+                specifies a list of legal or suggested choices for an &lt;xccdf:Value&gt; object.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="choice" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A single choice holding a simple type. (I.e.,
+                        number, string, or boolean.) </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="complex-choice" type="cdf:complexValueType" minOccurs="1"
+                maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A single choice holding a list of simple
+                        types.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="mustMatch" type="xsd:boolean" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">True if the listed choices are the only permissible
+                    settings for the given &lt;xccdf:Value&gt;. False if choices not specified in
+                    this &lt;xccdf:choices&gt; element are acceptable settings for this
+                    &lt;xccdf:Value&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="selector" default="" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">This may be referenced from &lt;xccdf:Profile&gt;
+                    selection elements or used during manual tailoring to refine the application of
+                    the &lt;xccdf:Rule&gt;. If no selectors are specified for a given
+                    &lt;xccdf:Value&gt; by &lt;xccdf:Profile&gt; elements or manual tailoring, an
+                    &lt;xccdf:choice&gt; element with an empty or non-existent @selector attribute
+                    is activated. If a selector is applied that does not match the @selector
+                    attribute of any &lt;xccdf:choices&gt; element, then no &lt;xccdf:choices&gt;
+                    element is considered activated.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="selStringType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This type is for an element that has string content
+                and a @selector attribute for use in tailoring. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="selector" default="" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">This may be referenced from
+                            &lt;xccdf:Profile&gt; selection elements or used during manual tailoring
+                            to refine the application of this property. If no selectors are
+                            specified for a given property by &lt;xccdf:Profile&gt; elements or
+                            manual tailoring, properties with empty or non-existent @selector
+                            attributes are activated. If a selector is applied that does not match
+                            the @selector attribute of any of a given type of property, then no
+                            property of that type is considered activated. The only exception is the
+                            &lt;xccdf:value&gt; and &lt;xccdf:complex-value&gt; properties of an
+                            &lt;xccdf:Value&gt; element - if there is no &lt;xccdf:value&gt; or
+                            &lt;xccdf:complex-value&gt; property with a matching @selector value
+                            then the &lt;xccdf:value&gt;/&lt;xccdf:complex-value&gt; property with
+                            an empty or absent @selector attribute becomes active. If there is no
+                            such &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt;, then the first
+                            &lt;xccdf:value&gt; or &lt;xccdf:complex-value&gt; listed in the XML
+                            becomes active. This reflects the fact that all &lt;xccdf:Value&gt;
+                            elements require an active value property at all
+                            times.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="selNumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This type is for an element that has numeric content
+                and a @selector attribute for use during tailoring. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="selector" default="" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">This may be referenced from
+                            &lt;xccdf:Profile&gt; selection elements or used during manual tailoring
+                            to refine the application of this property. If no selectors are
+                            specified for a given property by &lt;xccdf:Profile&gt; elements or
+                            manual tailoring, properties with empty or non-existent @selector
+                            attributes are activated. If a selector is applied that does not match
+                            the @selector attribute of any of a given type of property, then no
+                            property of that type considered activated. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="uriRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for elements that have no content and a
+                single @uri attribute. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="uri" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">A URI.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:simpleType name="valueTypeType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Allowed data types for &lt;xccdf:Value&gt; elements,
+                string, numeric, and boolean. A tool may choose any convenient form to store an
+                &lt;xccdf:Value&gt; element’s &lt;xccdf:value&gt; element, but the @type conveys how
+                the value should be treated for user input validation purposes during tailoring
+                processing. The @type may also be used to give additional guidance to the user or to
+                validate the user’s input. For example, if an &lt;xccdf:value&gt; element’s @type
+                attribute is “number”, then a tool might choose to reject user tailoring input that
+                is not composed of digits. In the case of a list of values, the @type applies to all
+                elements of the list individually. Note that checking systems may have their own
+                understanding of data types that may not be identical to the typing indicated in
+                XCCDF </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="number">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A numeric value. This may be decimal or
+                        integer.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="string">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Any character data</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="boolean">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">True/false</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="valueOperatorType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> This type enumerates allowed values of the @operator
+                property of &lt;xccdf:Value&gt; elements. The specific interpretation of these
+                operators depends on the checking system used. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="equals"/>
+            <xsd:enumeration value="not equal"/>
+            <xsd:enumeration value="greater than"/>
+            <xsd:enumeration value="less than"/>
+            <xsd:enumeration value="greater than or equal"/>
+            <xsd:enumeration value="less than or equal"/>
+            <xsd:enumeration value="pattern match"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="interfaceHintType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Allowed interface hint values. &lt;xccdf:Value&gt;
+                elements may contain a hint or recommendation to a benchmark consumer or producer
+                about how the user might select or adjust the &lt;xccdf:Value&gt;. This type
+                enumerates the possible values of this hint.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="choice">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Multiple choice</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="textline">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Multiple lines of text</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="text">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Single line of text</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="date">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Date</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="datetime">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Date and time</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- ************************************************************** -->
+    <!-- *******************  Profile Element  ************************ -->
+    <!-- ************************************************************** -->
+    <xsd:element name="Profile" type="cdf:profileType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The &lt;xccdf:Profile&gt; element is a named tailoring
+                for an &lt;xccdf:Benchmark&gt;. While an &lt;xccdf:Benchmark&gt; can be tailored in
+                place by setting properties of various elements, &lt;xccdf:Profile&gt; elements
+                allow one &lt;xccdf:Benchmark&gt; document to hold several independent
+                tailorings.</xsd:documentation>
+        </xsd:annotation>
+        <!-- selector key constraints -->
+        <xsd:unique name="itemSelectKey">
+            <xsd:selector xpath="./cdf:select"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:unique>
+        <xsd:unique name="refineRuleKey">
+            <xsd:selector xpath="./cdf:refine-rule"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:unique>
+        <xsd:unique name="refineValueKey">
+            <xsd:selector xpath="./cdf:refine-value"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:unique>
+        <xsd:unique name="setValueKey">
+            <xsd:selector xpath="./cdf:set-value"/>
+            <xsd:field xpath="@idref"/>
+        </xsd:unique>
+    </xsd:element>
+
+    <xsd:complexType name="profileType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:Profile&gt; element, which
+                holds a specific tailoring of the &lt;xccdf:Benchmark&gt;. The main part of an
+                &lt;xccdf:Profile&gt; is the selectors: &lt;xccdf:select&gt;,
+                &lt;xccdf:set-value&gt;, &lt;xccdf:set-complex-value&gt;, &lt;xccdf:refine-rule&gt;,
+                and &lt;xccdf:refine-value&gt;. An &lt;xccdf:Profile&gt; may also be signed with an
+                XML-Signature. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element ref="cdf:status" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Status of the &lt;xccdf:Profile&gt; and date at
+                        which it attained that status. Authors may use this element to record the
+                        maturity or consensus level of an &lt;xccdf:Profile&gt;. If the
+                        &lt;xccdf:status&gt; is not given explicitly, then the &lt;xccdf:Profile&gt;
+                        is taken to have the same status as its parent
+                        &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dc-status" minOccurs="0" maxOccurs="unbounded"
+                type="cdf:dc-statusType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds additional status information using the
+                        Dublin Core format.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="version" type="cdf:versionType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Version information about this
+                        &lt;xccdf:Profile&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="title" type="cdf:textWithSubType" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Title of the &lt;xccdf:Profile&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="description" type="cdf:htmlTextWithSubType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Text that describes the &lt;xccdf:Profile&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="reference" type="cdf:referenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A reference where the user can learn more about
+                        the subject of this &lt;xccdf:Profile&gt;.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="platform" type="cdf:overrideableCPE2idrefType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A target platform for this
+                        &lt;xccdf:Profile&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="select" minOccurs="0" type="cdf:profileSelectType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Select or deselect &lt;xccdf:Group&gt; and
+                            &lt;xccdf:Rule&gt; elements. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="set-complex-value" minOccurs="0"
+                    type="cdf:profileSetComplexValueType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Set the value of an &lt;xccdf:Value&gt; to
+                            a list.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="set-value" minOccurs="0" type="cdf:profileSetValueType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Set the value of an &lt;xccdf:Value&gt; to
+                            a simple data value.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="refine-value" minOccurs="0" type="cdf:profileRefineValueType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Customize the properties of an
+                            &lt;xccdf:Value&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="refine-rule" minOccurs="0" type="cdf:profileRefineRuleType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Customize the properties of an
+                            &lt;xccdf:Rule&gt; or &lt;xccdf:Group&gt;.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Metadata associated with this
+                        &lt;xccdf:Profile&gt;.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="signature" type="cdf:signatureType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A digital signature asserting authorship and
+                        allowing verification of the integrity of the
+                        &lt;xccdf:Profile&gt;.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="cdf:profileIdType" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Unique identifier for this
+                    &lt;xccdf:Profile&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="prohibitChanges" type="xsd:boolean" default="false" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Whether or not products should prohibit changes to
+                    this &lt;xccdf:Profile&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="abstract" type="xsd:boolean" default="false" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">If true, then this &lt;xccdf:Profile&gt; exists
+                    solely to be extended by other &lt;xccdf:Profile&gt; elements.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="note-tag" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Tag identifier to specify which
+                    &lt;xccdf:profile-note&gt; element from an &lt;xccdf:Rule&gt; should be
+                    associated with this &lt;xccdf:Profile&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="extends" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The id of an &lt;xccdf:Profile&gt; on which to base
+                    this &lt;xccdf:Profile&gt;.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute ref="xml:base"/>
+        <xsd:attribute name="Id" type="xsd:ID" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier used for referencing elements
+                    included in an XML signature.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <!-- ************************************************************** -->
+    <!-- ***************  Profile-related Types *********************** -->
+    <!-- ************************************************************** -->
+    <xsd:complexType name="profileSelectType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for the &lt;xccdf:select&gt; element in an
+                &lt;xccdf:Profile&gt;. This element designates an &lt;xccdf:Rule&gt;,
+                &lt;xccdf:Group&gt;, or cluster of &lt;xccdf:Rule&gt; and &lt;xccdf:Group&gt;
+                elements and overrides the @selected attribute on the designated items, providing a
+                means for including or excluding &lt;xccdf:Rule&gt; elements from an
+                assessment.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="remark" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Explanatory material or other
+                        prose.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="idref" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The @id value of an &lt;xccdf:Rule&gt; or
+                    &lt;xccdf:Group&gt;, or the @cluster-id value of one or more &lt;xccdf:Rule&gt;
+                    or &lt;xccdf:Group&gt; elements. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="selected" type="xsd:boolean" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The new value for the indicated item's @selected
+                    property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="profileSetValueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for the &lt;xccdf:set-value&gt; element in an
+                &lt;xccdf:Profile&gt;. This element upports the direct specification of simple value
+                types such as numbers, strings, and boolean values. This overrides the
+                &lt;xccdf:value&gt; and &lt;xccdf:complex-value&gt; element(s) of an
+                &lt;xccdf:Value&gt; element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="idref" type="xsd:NCName" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The @id value of an &lt;xccdf:Value&gt; or
+                            the @cluster-id value of one or more &lt;xccdf:Value&gt; elements
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="profileSetComplexValueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for the &lt;xccdf:set-complex-value&gt; element
+                in an &lt;xccdf:Profile&gt;. This element supports the direct specification of
+                complex value types such as lists. Zero or more &lt;xccdf:item&gt; elements may
+                appear as children of this element; if no child elements are present, this element
+                represents an empty list. This overrides the &lt;xccdf:value&gt; and
+                &lt;xccdf:complex-value&gt; element(s) of an &lt;xccdf:Value&gt;
+                element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:complexValueType">
+                <xsd:attribute name="idref" type="xsd:NCName" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The @id value of an &lt;xccdf:Value&gt; or
+                            the @cluster-id value of one or more &lt;xccdf:Value&gt; elements
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="profileRefineValueType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for the &lt;xccdf:refine-value&gt; element in an
+                &lt;xccdf:Profile&gt;. This element designates the &lt;xccdf:Value&gt; constraints
+                to be applied during tailoring for an &lt;xccdf:Value&gt; element or the
+                &lt;xccdf:Value&gt; members of a cluster. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="remark" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Explanatory material or other
+                        prose.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="idref" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The @id value of an &lt;xccdf:Value&gt; or the
+                    @cluster-id value of one or more &lt;xccdf:Value&gt; elements
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="selector" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Holds a selector value corresponding to the value
+                    of a @selector property in an &lt;xccdf:Value&gt; element's child properties.
+                    Properties with a matching @selector are considered active and all other
+                    properties are inactive. This may mean that, after selector application, some
+                    classes of &lt;xccdf:Value&gt; properties will be completely inactive because
+                    none of those properties had a matching @selector. The only exception is the
+                    &lt;xccdf:value&gt; and &lt;xccdf:complex-value&gt; properties of an
+                    &lt;xccdf:Value&gt; element - if there is no &lt;xccdf:value&gt; or
+                    &lt;xccdf:complex-value&gt; property with a matching @selector value then the
+                    &lt;xccdf:value&gt;/&lt;xccdf:complex-value&gt; property with an empty or absent
+                    @selector attribute becomes active. If there is no such &lt;xccdf:value&gt; or
+                    &lt;xccdf:complex-value&gt;, then the first &lt;xccdf:value&gt; or
+                    &lt;xccdf:complex-value&gt; listed in the XML becomes active. This reflects the
+                    fact that all &lt;xccdf:Value&gt; elements require an active value property at
+                    all times. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="operator" type="cdf:valueOperatorType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The new value for the identified
+                    &lt;xccdf:Value&gt; element's @operator property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="profileRefineRuleType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for the &lt;xccdf:refine-rule&gt; element in an
+                &lt;xccdf:Profile&gt;. A &lt;xccdf:refine-rule&gt; element allows the author to
+                select &lt;xccdf:check&gt; statements and override the @weight, @severity, and @role
+                of an &lt;xccdf:Rule&gt;, &lt;xccdf:Group&gt;, or cluster of &lt;xccdf:Rule&gt; and
+                &lt;xccdf:Group&gt; elements. Despite the name, this selector does apply for
+                &lt;xccdf:Group&gt; elements and for clusters that include &lt;xccdf:Group&gt;
+                elements, but it only affects their @weight attribute. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="remark" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Explanatory material or other
+                        prose.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="idref" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The @id value of an &lt;xccdf:Rule&gt; or
+                    &lt;xccdf:Group&gt;, or the @cluster-id value of one or more &lt;xccdf:Rule&gt;
+                    or &lt;xccdf:Group&gt; elements. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="weight" type="cdf:weightType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The new value for the identified element's @weight
+                    property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="selector" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Holds a selector value corresponding to the value
+                    of a @selector property in an &lt;xccdf:Rule&gt; element's &lt;xccdf:check&gt;
+                    element. If the selector specified does not match any of the @selector
+                    attributes specified on any of the &lt;xccdf:check&gt; children of an
+                    &lt;xccdf:Rule&gt;, then the &lt;xccdf:check&gt; child element without a
+                    @selector attribute is used. If there is no child without a @selector attribute,
+                    then that Rule would have no effective &lt;xccdf:check&gt;
+                    element.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="severity" type="cdf:severityEnumType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The new value for the identified &lt;xccdf:Rule&gt;
+                    element's @severity property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="role" type="cdf:roleEnumType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The new value for the identified &lt;xccdf:Rule&gt;
+                    element's @role property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <!-- ************************************************************** -->
+    <!-- *******************  TestResult Element  ********************* -->
+    <!-- ************************************************************** -->
+    <xsd:element name="TestResult" type="cdf:testResultType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The &lt;xccdf:TestResult&gt; element encapsulates the
+                results of a single application of an &lt;xccdf:Benchmark&gt; to a single target
+                platform. The &lt;xccdf:TestResult&gt; element normally appears as the child of the
+                &lt;xccdf:Benchmark&gt; element, although it may also appear as the top-level
+                element of an XCCDF results document. XCCDF is not intended to be a database format
+                for detailed results; the &lt;xccdf:TestResult&gt; element offers a way to store the
+                results of individual tests in modest detail, with the ability to reference
+                lower-level testing data.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="testResultType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:TestResult&gt; element,
+                which holds the results of one application of the &lt;xccdf:Benchmark&gt;. The
+                &lt;xccdf:TestResult&gt; element normally appears as the child of the
+                &lt;xccdf:Benchmark&gt; element, although it may also appear as the top-level
+                element of an XCCDF results document. XCCDF is not intended to be a database format
+                for detailed results; the &lt;xccdf:TestResult&gt; element offers a way to store the
+                results of individual tests in modest detail, with the ability to reference
+                lower-level testing data. Although several of the child elements of this type
+                technically support the @override attribute, the &lt;xccdf:TestResult&gt; element
+                cannot be extended. Therefore, @override has no meaning within an
+                &lt;xccdf:TestResult&gt; element and its children, and should not be used for
+                them.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="benchmark" minOccurs="0" maxOccurs="1"
+                type="cdf:benchmarkReferenceType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Reference to the &lt;xccdf:Benchmark&gt; for
+                        which the &lt;xccdf:TestResult&gt; records results. This property is
+                        required if this &lt;xccdf:TestResult&gt; element is the top-level element
+                        and optional otherwise.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="tailoring-file" minOccurs="0" maxOccurs="1"
+                type="cdf:tailoringReferenceType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The tailoring file element contains attributes
+                        used to identify an &lt;xccdf:Tailoring&gt; element used to guide the
+                        assessment reported on in this &lt;xccdf:TestResult&gt;. The tailoring
+                        element is required in an &lt;xccdf:TestResult&gt; if and only if an
+                        &lt;xccdf:Tailoring&gt; element guided the assessment recorded in the
+                        &lt;xccdf:TestResult&gt; or if the &lt;xccdf:Tailoring&gt; element records
+                        manual tailoring actions applied to this assessment. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="title" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Title of the test.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="remark" type="cdf:textType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A remark about the test, possibly supplied by
+                        the person administering the &lt;xccdf:Benchmark&gt;
+                        assessment</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="organization" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The name of the organization or other entity
+                        responsible for applying this &lt;xccdf:Benchmark&gt; and generating this
+                        result. When multiple &lt;xccdf:organization&gt; elements are used to
+                        indicate multiple organization names in a hierarchical organization, the
+                        highest-level organization should appear first. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="identity" type="cdf:identityType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Information about the system identity or user
+                        employed during application of the &lt;xccdf:Benchmark&gt;. If used,
+                        specifies the name of the authenticated identity.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="profile" type="cdf:idrefType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:profile&gt; element holds the
+                        value of the @id attribute value of the &lt;xccdf:Profile&gt; selected to be
+                        used in the assessment reported on by this &lt;xccdf:TestResult&gt;. This
+                        &lt;xccdf:Profile&gt; might be from the &lt;xccdf:Benchmark&gt; or from an
+                        &lt;xccdf:Tailoring&gt; file, if used. This element should appear if and
+                        only if an &lt;xccdf:Profile&gt; was selected to guide the
+                        assessment.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="target" type="xsd:string" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Name or description of the target system whose
+                        test results are recorded in the &lt;xccdf:TestResult&gt; element (the
+                        system to which an &lt;xccdf:Benchmark&gt; test was applied). Each
+                        appearance of the element supplies a name by which the target host or device
+                        was identified at the time the test was run. The name may be any string, but
+                        applications should include the fully qualified DNS name whenever possible.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="target-address" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Network address of the target system to which
+                        an &lt;xccdf:Benchmark&gt; test was applied. Typical forms for the address
+                        include IP version 4 (IPv4), IP version 6 (IPv6), and Ethernet media access
+                        control (MAC).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="target-facts" type="cdf:targetFactsType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A list of named facts about the target system
+                        or platform. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="target-id-ref" type="cdf:targetIdRefType">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">References to external structures with
+                            identifying information about the target of this
+                            assessment.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:any namespace="##other" processContents="lax">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Identifying information expressed in other
+                            XML formats can be included here. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:any>
+            </xsd:choice>
+            <xsd:element name="platform" type="cdf:CPE2idrefType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A platform on the target system. There should
+                        be one instance of this property for every platform that the target system
+                        was found to meet. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="set-value" type="cdf:profileSetValueType" minOccurs="1"
+                    maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Specific setting for a single
+                            &lt;xccdf:Value&gt; element used during the test.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="set-complex-value" type="cdf:profileSetComplexValueType"
+                    minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Specific setting for a single
+                            &lt;xccdf:Value&gt; element used during the test when the given value is
+                            set to a complex type, such as a list.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="rule-result" type="cdf:ruleResultType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The result of a single instance of an
+                        &lt;xccdf:Rule&gt; application against the target. The
+                        &lt;xccdf:TestResult&gt; must include at least one &lt;xccdf:rule-result&gt;
+                        record for each &lt;xccdf:Rule&gt; that was selected in the resolved
+                        &lt;xccdf:Benchmark&gt;.</xsd:documentation>
+                </xsd:annotation>
+                <!-- Each context name in an instance must be unique. -->
+                <xsd:key name="instanceContextKey">
+                    <xsd:selector xpath="cdf:instance"/>
+                    <xsd:field xpath="@context"/>
+                </xsd:key>
+                <!-- parentContext must refer to valid sibling context -->
+                <xsd:keyref name="parentKeyRef" refer="cdf:instanceContextKey">
+                    <xsd:selector xpath="./cdf:instance"/>
+                    <xsd:field xpath="@parentContext"/>
+                </xsd:keyref>
+            </xsd:element>
+            <xsd:element name="score" type="cdf:scoreType" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">An overall score for this
+                        &lt;xccdf:Benchmark&gt; test. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">XML metadata associated with this
+                        &lt;xccdf:TestResult&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="signature" type="cdf:signatureType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A digital signature asserting authorship and
+                        allowing verification of the integrity of the &lt;xccdf:TestResult&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="cdf:testresultIdType" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Unique identifier for this
+                    element.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="start-time" type="xsd:dateTime" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Time when testing began.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="end-time" type="xsd:dateTime" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Time when testing was completed and the results
+                    recorded. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="test-system" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Name of the benchmark consumer program that
+                    generated this &lt;xccdf:TestResult&gt; element; should be either a CPE name or
+                    a CPE applicability language expression.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The version number string copied from the
+                    &lt;xccdf:Benchmark&gt; used to direct this assessment. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="Id" type="xsd:ID" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier used for referencing elements
+                    included in an XML signature.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="benchmarkReferenceType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for a reference to the &lt;xccdf:Benchmark&gt;
+                document. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="href" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The URI of the &lt;xccdf:Benchmark&gt; document.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="id" type="xsd:NCName" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of that &lt;xccdf:Benchmark&gt; element's
+                    @id attribute. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="scoreType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for a score value in an &lt;xccdf:TestResult&gt;.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="system" type="xsd:anyURI" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A URI indicating the scoring model used to
+                            create this score. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="maximum" type="xsd:decimal" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The maximum possible score value that could
+                            have been achieved under the named scoring system. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="targetFactsType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:target-facts&gt; elements
+                in &lt;xccdf:TestResult&gt; elements. A &lt;xccdf:target-facts&gt; element holds a
+                list of named facts about the target system or platform. Each fact is an element of
+                type factType. Each &lt;xccdf:fact&gt; must have a name, but duplicate names are
+                allowed. (For example, if you had a fact about MAC addresses, and the target system
+                had three NICs, then you'd need three instances of the "urn:xccdf:fact:ethernet:MAC"
+                fact.) </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="fact" type="cdf:factType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A named fact about the target system or
+                        platform.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="targetIdRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for an &lt;xccdf:target-id-ref&gt; element in an
+                &lt;xccdf:TestResult&gt; element. This element contains references to external
+                structures with identifying information about the target of an
+                assessment.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="system" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Indicates the language in which this identifying
+                    information is expressed. If the identifying language uses XML namespaces, then
+                    the @system attribute for the language should be its
+                    namespace.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="href" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Points to the external resource (e.g., a file) that
+                    contains the identifying information.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="name" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Identifies a specific structure within the
+                    referenced file. If the @name attribute is absent, the reference is to the
+                    entire resource indicated in the @href attribute.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="identityType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for an &lt;xccdf:identity&gt; element in an
+                &lt;xccdf:TestResult&gt;. It contains information about the system identity or user
+                employed during application of the &lt;xccdf:Benchmark&gt;. If used, shall specify
+                the name of the authenticated identity. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="authenticated" type="xsd:boolean" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Whether the identity was authenticated with
+                            the target system during the application of the &lt;xccdf:Benchmark&gt;.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="privileged" type="xsd:boolean" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Whether the identity was granted
+                            administrative or other special privileges beyond those of a normal
+                            user. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="factType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for an &lt;xccdf:fact&gt; element, which
+                holds information about a target system: a name-value pair with a type. The content
+                of the element is the value, and the @name attribute indicates the name. The @name
+                is in the form of a URI that indicates the nature of the fact. A table of defined
+                fact URIs appears in section 6.6.3 of the XCCDF specification. Additional URIs may
+                be defined by authors to indicate additional kinds of facts. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:anyURI" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A URI that indicates the name of the fact.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="type" type="cdf:valueTypeType" default="boolean" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The data type of the fact value.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="tailoringReferenceType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for the &lt;xccdf:tailoring&gt; element within an
+                &lt;xccdf:TestResult&gt;. This element is used to indicate the identity and location
+                of an &lt;xccdf:Tailoring&gt; file that was used to create the assessment results.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="href" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The URI of the &lt;xccdf:Tailoring&gt; file's
+                    location. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="id" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The &lt;xccdf:Tailoring&gt; element's @id value.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the &lt;xccdf:Tailoring&gt; element's
+                    &lt;xccdf:version&gt; property. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="time" type="xsd:dateTime" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @time attribute in the
+                    &lt;xccdf:Tailoring&gt; element's &lt;xccdf:version&gt;
+                    property.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="ruleResultType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for the &lt;xccdf:rule-result&gt; element within
+                an &lt;xccdf:TestResult&gt;. An &lt;xccdf:rule-result&gt; holds the result of
+                applying an &lt;xccdf:Rule&gt; from the &lt;xccdf:Benchmark&gt; to a target system
+                or component of a target system. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="result" type="cdf:resultEnumType" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Result of applying the referenced
+                        &lt;xccdf:Rule&gt; to a target or target component. (E.g., Pass, Fail, etc.)
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="override" type="cdf:overrideType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">An XML block explaining how and why an auditor
+                        chose to override the result. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ident" type="cdf:identType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A long-term globally meaningful identifier for
+                        the issue, vulnerability, platform, etc. copied from the referenced
+                        &lt;xccdf:Rule&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">XML metadata associated with this
+                        &lt;xccdf:rule-result&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="message" type="cdf:messageType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Diagnostic messages from the checking engine.
+                        These elements do not affect scoring; they are present merely to convey
+                        diagnostic information from the checking engine. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="instance" type="cdf:instanceResultType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Name of the target subsystem or component to
+                        which this result applies, for a multiply instantiated &lt;xccdf:Rule&gt;.
+                        The element is important for an &lt;xccdf:Rule&gt; that applies to
+                        components of the target system, especially when a target might have several
+                        such components, and where the @multiple attribute of the &lt;xccdf:Rule&gt;
+                        is set to true.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fix" type="cdf:fixType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Fix script for this target platform, if
+                        available (would normally appear only for result values of “fail”). It is
+                        assumed to have been ‘instantiated’ by the testing tool and any
+                        substitutions or platform selections already made.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:choice>
+                <xsd:element name="check" type="cdf:checkType" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Encapsulated or referenced results to
+                            detailed testing output from the checking engine (if
+                            any).</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="complex-check" minOccurs="0" type="cdf:complexCheckType"
+                    maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">A copy of the &lt;xccdf:Rule&gt; element’s
+                            &lt;xccdf:complex-check&gt; element where each component
+                            &lt;xccdf:check&gt; element of the &lt;xccdf:complex-check&gt; element
+                            is an encapsulated or referenced results to detailed testing output from
+                            the checking engine (if any) as described in the
+                            &lt;xccdf:rule-result&gt; &lt;xccdf:check&gt;
+                            property.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+        <xsd:attribute name="idref" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @id property of an
+                    &lt;xccdf:Rule&gt;. This &lt;xccdf:rule-result&gt; reflects the result of
+                    applying this &lt;xccdf:Rule&gt; to a target or target component.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="role" type="cdf:roleEnumType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @role property of the referenced
+                    &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="severity" type="cdf:severityEnumType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @severity property of the
+                    referenced &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="time" type="xsd:dateTime" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Time when application of this instance of the
+                    referenced &lt;xccdf:Rule&gt; was completed. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="version" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @version property of the
+                    referenced &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="weight" type="cdf:weightType" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The value of the @weight property of the referenced
+                    &lt;xccdf:Rule&gt;. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="instanceResultType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for an &lt;xccdf:instance&gt; element in an
+                &lt;xccdf:rule-result&gt;. The content is a string, but the element may also have
+                two attributes: @context and @parentContext. Both attributes are intended to provide
+                hints as to the nature of the substituted content. This body of this type records
+                the details of the target system instance for multiply instantiated
+                &lt;xccdf:Rule&gt; elements. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="context" default="undefined" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Describes the scope or significance of the
+                            instance content. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="parentContext" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Used to express nested structure in
+                            instance context structures. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="overrideType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for an &lt;xccdf:override&gt; element in an
+                &lt;xccdf:rule-result&gt;. This element is used to record manual modification or
+                annotation of a particular &lt;xccdf:rule-result&gt;. All attributes and child
+                elements are required. It will not always be the case that the
+                &lt;xccdf:new-result&gt; value will differ from the &lt;xccdf:old-result&gt; value.
+                They might match if an authority wished to make a remark on the result without
+                changing it. If &lt;xccdf:new-result&gt; and &lt;xccdf:old-result&gt; differ, the
+                &lt;xccdf:result&gt; element of the enclosing &lt;xccdf:rule-result&gt; must match
+                the &lt;xccdf:new-result&gt; value.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="old-result" type="cdf:resultEnumType" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:rule-result&gt; status before
+                        this override. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="new-result" type="cdf:resultEnumType" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The new, override &lt;xccdf:rule-result&gt;
+                        status. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="remark" type="cdf:textType" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Rationale or explanation text for why or how
+                        the override was applied. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="time" type="xsd:dateTime" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">When the override was applied. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="authority" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Name or other identification for the human
+                    principal authorizing the override. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="messageType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Type for a message generated by the checking engine or
+                XCCDF tool during &lt;xccdf:Benchmark&gt; testing. The message is contained in
+                string format in the body of the element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="severity" type="cdf:msgSevEnumType" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Denotes the seriousness of the
+                            message.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="msgSevEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Allowed values to indicate the severity of messages
+                from the checking engine. These values don't affect scoring themselves but are
+                present merely to convey diagnostic information from the checking engine. Benchmark
+                consumers may choose to log these messages or display them to the user.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="error">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Denotes a serious problem identified; test did
+                        not run. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="warning">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Denotes a possible issue; test may not have
+                        run. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="info">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Denotes important information about the tests.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="resultEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Allowed result indicators for a
+                test.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="pass">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The target system or system component satisfied
+                        all the conditions of the &lt;xccdf:Rule&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="fail">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The target system or system component did not
+                        satisfy all the conditions of the &lt;xccdf:Rule&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="error">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The checking engine could not complete the
+                        evaluation; therefore the status of the target’s compliance with the
+                        &lt;xccdf:Rule&gt; is not certain. This could happen, for example, if a
+                        testing tool was run with insufficient privileges and could not gather all
+                        of the necessary information. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="unknown">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The testing tool encountered some problem and
+                        the result is unknown. For example, a result of ‘unknown’ might be given if
+                        the testing tool was unable to interpret the output of the checking engine
+                        (the output has no meaning to the testing tool). </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="notapplicable">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; was not applicable to
+                        the target of the test. For example, the &lt;xccdf:Rule&gt; might have been
+                        specific to a different version of the target OS, or it might have been a
+                        test against a platform feature that was not installed. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="notchecked">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; was not evaluated by the
+                        checking engine. This status is designed for &lt;xccdf:Rule&gt; elements
+                        that have no check. It may also correspond to a status returned by a
+                        checking engine if the checking engine does not support the indicated check
+                        code. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="notselected">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; was not selected in the
+                        &lt;xccdf:Benchmark&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="informational">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; was checked, but the
+                        output from the checking engine is simply information for auditors or
+                        administrators; it is not a compliance category. This status value is
+                        designed for &lt;xccdf:Rule&gt; elements whose main purpose is to extract
+                        information from the target rather than test the target.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="fixed">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The &lt;xccdf:Rule&gt; had failed, but was then
+                        fixed (possibly by a tool that can automatically apply remediation, or
+                        possibly by the human auditor). </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="severityEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Allowed severity values for the @severity attribute of
+                an &lt;xccdf:Rule&gt;. The value of this attribute provides an indication of the
+                importance of the &lt;xccdf:Rule&gt; element's recommendation. This information is
+                informative only and does not affect scoring.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="unknown">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Severity not defined (default).
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="info">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">&lt;xccdf:Rule&gt; is informational and failure
+                        does not represent a problem. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="low">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Not a serious problem. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="medium">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Fairly serious problem. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="high">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A grave or critical problem.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="roleEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Allowed checking and scoring roles for an
+                &lt;xccdf:Rule&gt;.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="full">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">If the &lt;xccdf:Rule&gt; is selected, then
+                        check it and let the result contribute to the score and appear in reports
+                        (default). </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="unscored">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">If the &lt;xccdf:Rule&gt; is selected, then
+                        check it and include it in the test report, but give the result a status of
+                        informational and do not use the result in score computations.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="unchecked">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Do not check the &lt;xccdf:Rule&gt;; just force
+                        the result status to notchecked. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="subUseEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">This holds the possible values of the @use attribute
+                within an &lt;xccdf:sub&gt; element. The @use attribute is only applicable with the
+                subType's @idref attribute holds the value of the @id of an &lt;xccdf:Value&gt;
+                element.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="value">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Replace with the selected &lt;xccdf:value&gt;
+                        or &lt;xccdf:complex-value&gt; of an &lt;xccdf:Value&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="title">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Replace with the &lt;xccdf:title&gt; of the
+                        &lt;xccdf:Value&gt;. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="legacy">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Use the context-dependent processing of
+                        &lt;xccdf:sub&gt; elements outlined in XCCDF 1.1.4. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:element name="Tailoring" type="cdf:tailoringType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">The &lt;xccdf:Tailoring&gt; element holds one or more
+                &lt;xccdf:Profile&gt; elements. These &lt;xccdf:Profile&gt; elements record
+                additional tailoring activities that apply to a given &lt;xccdf:Benchmark&gt;.
+                &lt;xccdf:Tailoring&gt; elements are separate from &lt;xccdf:Benchmark&gt;
+                documents, but each &lt;xccdf:Tailoring&gt; element is associated with a specific
+                &lt;xccdf:Benchmark&gt; document. By defining these tailoring actions separately
+                from the &lt;xccdf:Benchmark&gt; document to which they apply, these actions can be
+                recorded without affecting the integrity of the source itself.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="tailoringType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Data type for the &lt;xccdf:Tailoring&gt; element. The
+                &lt;xccdf:Tailoring&gt; element allows named tailorings (i.e., &lt;xccdf:Profile&gt;
+                elements) of an &lt;xccdf:Benchmark&gt; to be defined separately from the
+                &lt;xccdf:Benchmark&gt; itself. The &lt;xccdf:Profile&gt; elements in an
+                &lt;xccdf:Tailoring&gt; element can be used in two ways: First, an organization
+                might wish to pre-define a set of tailoring actions to be applied on top of or
+                instead of the tailoring performed by an &lt;xccdf:Benchmark&gt; element's
+                &lt;xccdf:Profile&gt; elements. Second, an &lt;xccdf:Tailoring&gt; element can be
+                used to record manual tailoring actions performed during the course of an
+                assessment. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="benchmark" minOccurs="0" maxOccurs="1"
+                type="cdf:tailoringBenchmarkReferenceType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Identifies the &lt;xccdf:Benchmark&gt; to which
+                        this tailoring applies. A &lt;xccdf:Tailoring&gt; document is only
+                        applicable to a single &lt;xccdf:Benchmark&gt;. Note, however, that this is
+                        a purely informative field. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="cdf:status" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Status of the tailoring and date at which it
+                        attained that status. Authors may use this element to record the maturity or
+                        consensus level of an &lt;xccdf:Tailoring&gt; element.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dc-status" minOccurs="0" maxOccurs="unbounded"
+                type="cdf:dc-statusType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds additional status information using the
+                        Dublin Core format. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="version" minOccurs="1" maxOccurs="1" type="cdf:tailoringVersionType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The version of this &lt;xccdf:Tailoring&gt;
+                        element, with a required @time attribute that records when the
+                        &lt;xccdf:Tailoring&gt; element was created. This timestamp is necessary
+                        because, under some circumstances, a copy of an &lt;xccdf:Tailoring&gt;
+                        document might be automatically generated. Without the version and
+                        timestamp, tracking of these automatically created &lt;xccdf:Tailoring&gt;
+                        documents could become problematic. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="metadata" type="cdf:metadataType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">XML metadata for the &lt;xccdf:Tailoring&gt;
+                        element. </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="cdf:Profile" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">&lt;xccdf:Profile&gt; elements that reference
+                        and customize sets of items in an &lt;xccdf:Benchmark&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="signature" type="cdf:signatureType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">A digital signature asserting authorship and
+                        allowing verification of the integrity of the &lt;xccdf:Tailoring&gt;.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="cdf:tailoringIdType" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Unique identifier for this
+                    element.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <!-- the 'Id' attribute is needed for XML-Signature -->
+        <xsd:attribute name="Id" type="xsd:ID" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier used for referencing elements
+                    included in an XML signature. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="tailoringBenchmarkReferenceType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Identifies the &lt;xccdf:Benchmark&gt; to which an
+                &lt;xccdf:Tailoring&gt; element applies. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="cdf:benchmarkReferenceType">
+                <xsd:attribute name="version" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">Identifies the version of the referenced
+                            &lt;xccdf:Benchmark&gt;. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="tailoringVersionType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Type for version information about an
+                &lt;xccdf:Tailoring&gt; element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="time" type="xsd:dateTime" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">The time when this version of the
+                            &lt;xccdf:Tailoring&gt; document was completed. </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+</xsd:schema>
+<!-- CHANGELOG
+
+ date           change                  remarks
+
+6/20/05         added cdf:ident         long-term identifiers for Rule
+                                        and rule-result.
+
+6/21/05         enhanced version        added version attr to TestResult
+                                        and rule-result, too
+
+                added notapplicable     added new rule result value
+
+                added severity          enum and attributes
+
+6/22/05         added signatures for    need for standalone Rules & such
+                Rule,Group,Value,
+                Profile,TestResult
+
+6/22/05         added rule roles        at Dave's request
+
+6/23/05         added rule result       at DISA request
+                overrides
+
+6/26/05         added fixtext and       enums for attributes
+                fix enhancements
+
+6/29/05         added interactive       run-time tailoring for Values
+                attr on Value object
+
+6/29/05         added multiple scoring  was this a Dave request?
+                model support
+
+7/1/05          added support for       to support text re-use
+                named plain text blocks
+
+7/7/05          added target-facts      DISA suggestion
+
+7/13/05         added complex-checks    workshop suggestion, allow
+                                        boolean combinations of 
+                                        checks.
+
+7/29/05         added more rule         some suggested by CIS
+                result types
+
+8/4/05          added override attrs    suggested by Dave W.
+                for managing inheritance
+
+8/20/05         added fix strategies
+
+8/20/05         revamped complex-check  see OVAL schema
+                to more closely match
+                OVAL boolean operators
+
+9/4/05          fixed some typos
+
+9/8/05          Added fix/fixtext       suggested by Dave W.
+                complexity and warning
+                categories.
+
+9/18/05         Allow for XCCDF-P as    see XCCDF-P document
+                a platform type.        (later deprecated)
+
+9/21/05         Added profile-note      suggested by Dave W.
+                support.
+
+11/10/05        Added additional features   also from Dave W.
+                for Values.
+
+11/27/05        Added instance context   to meet CIS req'ts
+                support
+
+11/27/05        Added multiple hint on   to meet CIS req'ts
+                Rule object
+
+11/27/05        fixed role attr on       old bug
+                Rule object
+
+12/5/05         fixed 1.0-incompatible    reported by Nancy W
+                order glitch in Profile
+
+4/16/06         beginning work toward     reports from Ian C
+                1.1bis; fixed several 
+                small mistakes/glitches.
+
+4/23/06         tweaked formatting        various e-mails
+                fixed some comments
+                version # to 1.1.2.1
+
+4/30/06         fixed plain-text id       report from Dave W.
+                key and sub key ref
+
+5/5/06          fixed extends keyrefs     report from Dave W.
+
+5/21/06         added id attribute to     request from CIS
+                check element
+
+8/27/06         changed TestResult to     bug discovered myself
+                allow target to appear
+                multiple times
+
+11/20/06        Fixed weightType          report from Gary Gapinski
+
+12/13/06        Changed platform          support for CPE
+                references to URIs
+
+12/13/06        Changed requires element  request from NIST
+                to a token list
+
+12/28/06        Changed check element to   backfit to NIST 
+                allow multiple            change by Linda Devlin
+                check-content-ref
+
+8/21/07         Added check-import        better reporting, req.
+                element                   by NIST & MITRE
+
+8/26/07         Added remark element      allow authors to add
+                to Profile selectors      rationale to Profiles
+
+8/26/07         Added weight to rule      record weight used in
+                result element            a benchmark run
+
+8/30/07         Added impact-metric       mechanism to include a
+                element to Rule           CVSS score in a Rule
+
+8/30/07         Changed CPE support       Match SCAP 1.0
+                to CPE 2.0
+9/10/07         Made CPE 1.0 deprecated   Match SCAP 1.0
+
+10/8/07         Allow Profile selectors   Part of clarifying Profile
+                in any order              semantics for 1.1.4
+
+10/8/07         Added Benchmark style     For NIST SCAP
+                and style-href attrs
+
+10/8/07         Added organization and    For NIST SCAP
+                identity elements for
+                TestResult
+
+6/1/10          Made platform element       Fix to match spec
+                Profile overridable
+               
+6/1/10          Added metadata fields       Community request for
+                to TestResults, Profiles    more flexible metadata
+                and Items. Also opened
+                metadata fields to all
+                content.
+
+6/1/10          Updated to use CPE 2.3      Bring into line with SCAP
+                Also changed CPE fields
+                from URIs to strings.
+                
+6/1/10          Added negate field to       Support inverting of SCAP
+                check element.              result mappings
+
+6/1/10          Added dc-status field       Allow Dublin-Core status info
+
+6/1/10          Added multi-check to        Allows creation of rule-results
+                Rules                       for each check used
+
+6/1/10          Expanded selector           Enforce requirements from spec 
+                uniqueness constraints 
+                within Values
+                
+6/1/10          Expanded Value to           Bring XCCDF more in line with
+                allow lists and externally  capabilities of checking languages
+                defined types. Updated
+                Profile selectors and
+                TestResults to handle the
+                new constructs
+
+6/1/10          Added import-xpath to       Expand import capabilities
+                check-import. Also updated
+                check-import to allow
+                XML-structured findings
+                
+6/1/10          Fixed path of Benchmark's   Bug fix.
+                profileIdKeyRef restriction
+                
+6/1/10          Added an id field to        Better reference to the XCCDF source 
+                TestResult/benchmark
+                
+5/27/11         Added reference to Asset    More standards based target identification 
+                Identification structures
+                in TestResults.
+                
+5/27/11         Added ComplexChecks in      Better tracking of result structures during complex checks 
+                rule-results
+-->

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,6 +8,8 @@ PATH_TO_REMEDIATIONS_SCRIPTS = Path(__file__).parent / "test_data/remediations_s
 PATH_TO_EMPTY_XML_FILE = Path(__file__).parent / "test_data/empty.xml"
 PATH_TO_EMPTY_FILE = Path(__file__).parent / "test_data/empty.txt"
 
+PATH_TO_XML_FILE = Path(__file__).parent / "test_data/plant_catalog.xml"
+
 PATH_TO_ARF = Path(__file__).parent / "test_data/arf-report.xml"
 PATH_TO_SIMPLE_RULE_FAIL_ARF = Path(__file__).parent / "test_data/arf_simple_rule_fail.xml"
 PATH_TO_SIMPLE_RULE_PASS_ARF = Path(__file__).parent / "test_data/arf_simple_rule_pass.xml"

--- a/tests/integration_tests/test_basic_usage.py
+++ b/tests/integration_tests/test_basic_usage.py
@@ -1,0 +1,54 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import subprocess
+
+import pytest
+
+# pylint: disable-msg=R0801
+from ..constants import (PATH_TO_ARF,
+                         PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO,
+                         PATH_TO_ARF_SCANNED_ON_CONTAINER,
+                         PATH_TO_ARF_WITH_MULTI_CHECK,
+                         PATH_TO_ARF_WITH_OS_CPE_CHECK,
+                         PATH_TO_ARF_WITHOUT_INFO,
+                         PATH_TO_ARF_WITHOUT_SYSTEM_DATA,
+                         PATH_TO_RULE_AND_CPE_CHECK_ARF,
+                         PATH_TO_RULE_AND_CPE_CHECK_XCCDF,
+                         PATH_TO_SIMPLE_RULE_FAIL_ARF,
+                         PATH_TO_SIMPLE_RULE_FAIL_XCCDF,
+                         PATH_TO_SIMPLE_RULE_PASS_ARF,
+                         PATH_TO_SIMPLE_RULE_PASS_XCCDF, PATH_TO_XCCDF,
+                         PATH_TO_XCCDF_WITH_MULTI_CHECK,
+                         PATH_TO_XCCDF_WITHOUT_INFO,
+                         PATH_TO_XCCDF_WITHOUT_SYSTEM_DATA)
+
+OSCAP_REPORT_COMMAND = "oscap-report"
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        PATH_TO_ARF,
+        PATH_TO_SIMPLE_RULE_FAIL_ARF,
+        PATH_TO_SIMPLE_RULE_PASS_ARF,
+        PATH_TO_RULE_AND_CPE_CHECK_ARF,
+        PATH_TO_ARF_WITHOUT_INFO,
+        PATH_TO_ARF_WITHOUT_SYSTEM_DATA,
+        PATH_TO_ARF_WITH_MULTI_CHECK,
+        PATH_TO_ARF_WITH_OS_CPE_CHECK,
+        PATH_TO_ARF_SCANNED_ON_CONTAINER,
+        PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO,
+        PATH_TO_XCCDF,
+        PATH_TO_SIMPLE_RULE_FAIL_XCCDF,
+        PATH_TO_SIMPLE_RULE_PASS_XCCDF,
+        PATH_TO_RULE_AND_CPE_CHECK_XCCDF,
+        PATH_TO_XCCDF_WITHOUT_INFO,
+        PATH_TO_XCCDF_WITHOUT_SYSTEM_DATA,
+        PATH_TO_XCCDF_WITH_MULTI_CHECK,
+    ],
+)
+def test_oscap_report_basic_usage(file_path):
+    command_stdout = subprocess.check_output([OSCAP_REPORT_COMMAND, str(file_path)])
+    assert command_stdout.decode("utf-8").startswith("<!DOCTYPE html>")

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -11,7 +11,8 @@ from unittest import mock
 import pytest
 
 from openscap_report.cli import CommandLineAPI
-from openscap_report.scap_results_parser import SCAPResultsParser
+from openscap_report.scap_results_parser import (ARF_SCHEMAS_PATH,
+                                                 SCAPResultsParser)
 
 from ..constants import PATH_TO_ARF, PATH_TO_EMPTY_FILE
 
@@ -38,7 +39,7 @@ def test_load_file(mock_args):  # pylint: disable=W0613
     api = CommandLineAPI()
     xml_report = api.load_file()
     parser = SCAPResultsParser(xml_report)
-    assert parser.validate(parser.arf_schemas_path)
+    assert parser.validate(ARF_SCHEMAS_PATH)
     api.close_files()
 
 

--- a/tests/test_data/plant_catalog.xml
+++ b/tests/test_data/plant_catalog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CATALOG>
+  <PLANT>
+    <COMMON>Bloodroot</COMMON>
+    <BOTANICAL>Sanguinaria canadensis</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$2.44</PRICE>
+    <AVAILABILITY>031599</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Columbine</COMMON>
+    <BOTANICAL>Aquilegia canadensis</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$9.37</PRICE>
+    <AVAILABILITY>030699</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Wake Robin</COMMON>
+    <BOTANICAL>Trillium grandiflorum</BOTANICAL>
+    <ZONE>5</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$3.20</PRICE>
+    <AVAILABILITY>022199</AVAILABILITY>
+  </PLANT>
+</CATALOG>

--- a/tests/unit_tests/test_data_structure.py
+++ b/tests/unit_tests/test_data_structure.py
@@ -9,7 +9,11 @@ from openscap_report.scap_results_parser import MissingProcessableRules
 from openscap_report.scap_results_parser.data_structures import Remediation
 from tests.unit_tests.test_scap_result_parser import get_parser
 
-from ..constants import PATH_TO_ARF
+from ..constants import (PATH_TO_ARF, PATH_TO_ARF_SCANNED_ON_CONTAINER,
+                         PATH_TO_SIMPLE_RULE_FAIL_ARF,
+                         PATH_TO_SIMPLE_RULE_FAIL_XCCDF,
+                         PATH_TO_SIMPLE_RULE_PASS_ARF,
+                         PATH_TO_SIMPLE_RULE_PASS_XCCDF, PATH_TO_XCCDF)
 
 
 def get_report():
@@ -183,3 +187,19 @@ def test_report_severity_of_failed_rules_stats_without_failed_rules():
 def test_remediation_type(system, type_of_remediation):
     remediation = Remediation(remediation_id="ID-1234", system=system)
     assert remediation.get_type() == type_of_remediation
+
+
+@pytest.mark.unit_test
+@pytest.mark.parametrize("file_path, count_of_selected_rules", [
+    (PATH_TO_ARF, 714),
+    (PATH_TO_XCCDF, 712),
+    (PATH_TO_ARF_SCANNED_ON_CONTAINER, 121),
+    (PATH_TO_SIMPLE_RULE_FAIL_ARF, 1),
+    (PATH_TO_SIMPLE_RULE_FAIL_XCCDF, 1),
+    (PATH_TO_SIMPLE_RULE_PASS_ARF, 1),
+    (PATH_TO_SIMPLE_RULE_PASS_XCCDF, 1)
+])
+def test_report_get_selected_rules(file_path, count_of_selected_rules):
+    parser = get_parser(file_path)
+    report = parser.parse_report()
+    assert len(report.get_selected_rules()) == count_of_selected_rules


### PR DESCRIPTION
This PR fixes crashes when using the XCCDF report.

How to reproduce the problem: Use oscpa-report with XCCDF results.  
For example: `oscap-report < tests/test_data/xccdf-report.xml`

The crashes were caused by a missing part of the if condition. To avoid this problem, I created integration tests with all test files. And I discovered problems: 
* The first is that it is expected that the rule must be present in some of the groups.
* Missing selected rule definition, which should be a content issue that is fixed in later versions.
