### PR TITLE
Improvements to the runtime of unit tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from dataclasses import replace
+from functools import cache
+
+from lxml import etree
+
+from openscap_report.scap_results_parser import SCAPResultsParser
+from openscap_report.scap_results_parser.namespaces import NAMESPACES
+from openscap_report.scap_results_parser.parsers import RuleParser
+
+from .constants import (PATH_TO_ARF,
+                        PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO)
+
+
+@cache
+def get_xml_data(file_path):
+    with open(file_path, "r", encoding="utf-8") as xml_report:
+        return xml_report.read().encode()
+
+
+def get_parser(file_path):
+    xml_data = get_xml_data(file_path)
+    return SCAPResultsParser(xml_data)
+
+
+BASIC_REPORT = get_parser(PATH_TO_ARF).parse_report()
+
+
+def get_report(file_path=None):
+    if file_path is None:
+        return replace(BASIC_REPORT)
+    return get_parser(file_path).parse_report()
+
+
+REPORT_REPRODUCING_DANGLING_REFERENCE_TO = get_report(
+    PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO
+)
+
+
+def get_root(file_path):
+    xml_data = get_xml_data(file_path)
+    return etree.XML(xml_data)
+
+
+def get_benchmark(root):
+    benchmark_el = root.find(".//xccdf:Benchmark", NAMESPACES)
+    if "Benchmark" in root.tag:
+        return root
+    return benchmark_el
+
+
+def get_test_results(root):
+    return root.find(".//xccdf:TestResult", NAMESPACES)
+
+
+def get_ref_values(root):
+    return {
+        ref_value.get("idref"): ref_value.text
+        for ref_value in root.findall(".//xccdf:set-value", NAMESPACES)
+    }
+
+
+DEFAULT_RULES = BASIC_REPORT.rules
+
+
+def get_rules(file_path=None):
+    if file_path is None:
+        return DEFAULT_RULES.copy()
+    root = get_root(file_path)
+    test_results = get_test_results(root)
+    ref_values = get_ref_values(root)
+    rule_parser = RuleParser(root, test_results, ref_values)
+    return rule_parser.get_rules()

--- a/tests/unit_tests/test_data_structure.py
+++ b/tests/unit_tests/test_data_structure.py
@@ -7,18 +7,13 @@ import pytest
 
 from openscap_report.scap_results_parser import MissingProcessableRules
 from openscap_report.scap_results_parser.data_structures import Remediation
-from tests.unit_tests.test_scap_result_parser import get_parser
 
 from ..constants import (PATH_TO_ARF, PATH_TO_ARF_SCANNED_ON_CONTAINER,
                          PATH_TO_SIMPLE_RULE_FAIL_ARF,
                          PATH_TO_SIMPLE_RULE_FAIL_XCCDF,
                          PATH_TO_SIMPLE_RULE_PASS_ARF,
                          PATH_TO_SIMPLE_RULE_PASS_XCCDF, PATH_TO_XCCDF)
-
-
-def get_report():
-    parser = get_parser(PATH_TO_ARF)
-    return parser.parse_report()
+from ..test_utils import get_parser, get_report
 
 
 def remove_all_rules_by_result(report, result=()):

--- a/tests/unit_tests/test_full_text_parser.py
+++ b/tests/unit_tests/test_full_text_parser.py
@@ -1,11 +1,9 @@
 import pytest
 from lxml import etree
 
-from openscap_report.scap_results_parser import SCAPResultsParser
 from openscap_report.scap_results_parser.parsers import FullTextParser
 
-from ..constants import (PATH_TO_ARF,
-                         PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO)
+from ..test_utils import BASIC_REPORT, REPORT_REPRODUCING_DANGLING_REFERENCE_TO
 
 REF_VALUES = {
     "id-1234": "text1",
@@ -27,18 +25,7 @@ def test_replace_sub_tag(tag, return_data):
     assert FULL_TEXT_PARSER.replace_sub_tag(tag) == return_data
 
 
-def get_report(src):
-    with open(src, "r", encoding="utf-8") as report_file:
-        return SCAPResultsParser(report_file.read().encode()).parse_report()
-
-
-BASIC_REPORT = get_report(PATH_TO_ARF)
-REPORT_REPRODUCING_DANGLING_REFERENCE_TO = get_report(
-    PATH_TO_ARF_REPRODUCING_DANGLING_REFERENCE_TO
-)
-
-
-@pytest.mark.integration_test
+@pytest.mark.unit_test
 @pytest.mark.parametrize("report, rule_id, expected_data", [
     (
         REPORT_REPRODUCING_DANGLING_REFERENCE_TO,
@@ -82,5 +69,4 @@ REPORT_REPRODUCING_DANGLING_REFERENCE_TO = get_report(
     ),
 ])
 def test_parsing_of_text(report, rule_id, expected_data):
-    print(repr(report.rules[rule_id].description))
     assert report.rules[rule_id].description == expected_data


### PR DESCRIPTION
This PR improves the runtime of unit tests.

# Changes
* Reorganization of the help functions that sometimes was duplicated,
* Using cache for loading files,
* Some tests have been reclassified as unit tests,
* Reduce Report generation. 

## Benchmark
Run unit tests: `pytest -m "not integration_test"`
Used command for benchmark: `perf stat -r 10 pytest -m "not integration_test"`
### Before
183 tests
```
 Performance counter stats for 'pytest -m not integration_test' (10 runs):

         34 305,21 msec task-clock:u                     #    0,960 CPUs utilized            ( +-  2,00% )
                 0      context-switches:u               #    0,000 /sec                   
                 0      cpu-migrations:u                 #    0,000 /sec                   
         1 454 540      page-faults:u                    #   40,731 K/sec                    ( +-  0,23% )
   106 139 775 325      cycles:u                         #    2,972 GHz                      ( +-  0,79% )
   188 309 912 861      instructions:u                   #    1,74  insn per cycle           ( +-  0,01% )
    43 571 397 536      branches:u                       #    1,220 G/sec                    ( +-  0,03% )
       245 783 936      branch-misses:u                  #    0,56% of all branches          ( +-  0,44% )

            35,722 +- 0,685 seconds time elapsed  ( +-  1,92% )

```

### After
186 tests
```
 Performance counter stats for 'pytest -m not integration_test' (10 runs):

          9 560,19 msec task-clock:u                     #    0,918 CPUs utilized            ( +-  1,93% )
                 0      context-switches:u               #    0,000 /sec                   
                 0      cpu-migrations:u                 #    0,000 /sec                   
           227 427      page-faults:u                    #   21,869 K/sec                    ( +-  0,81% )
    30 180 023 326      cycles:u                         #    2,902 GHz                      ( +-  0,88% )
    53 070 003 330      instructions:u                   #    1,68  insn per cycle           ( +-  0,03% )
    12 455 634 065      branches:u                       #    1,198 G/sec                    ( +-  0,03% )
        85 307 313      branch-misses:u                  #    0,69% of all branches          ( +-  0,44% )

            10,411 +- 0,186 seconds time elapsed  ( +-  1,79% )
```