### PR TITLE
Change loading of OVAL result reports

### DIFF
--- a/openscap_report/scap_results_parser/data_structures/profile_info.py
+++ b/openscap_report/scap_results_parser/data_structures/profile_info.py
@@ -29,6 +29,9 @@ class ProfileInfo:
         return ", ".join(self.cpe_platforms_for_profile.keys())
 
     def get_cpe_platforms_that_satisfy_evaluation_target(self):
-        return ", ".join(
-            [cpe_id for cpe_id, is_satisfy in self.cpe_platforms_for_profile.items() if is_satisfy]
-        )
+        return ", ".join(self.get_list_of_cpe_platforms_that_satisfy_evaluation_target())
+
+    def get_list_of_cpe_platforms_that_satisfy_evaluation_target(self):
+        return [
+            cpe_id for cpe_id, is_satisfy in self.cpe_platforms_for_profile.items() if is_satisfy
+        ]

--- a/openscap_report/scap_results_parser/data_structures/rule.py
+++ b/openscap_report/scap_results_parser/data_structures/rule.py
@@ -47,6 +47,7 @@ class Rule:  # pylint: disable=R0902
     warnings: List[RuleWarning] = field(default_factory=list)
     platforms: List[str] = field(default_factory=list)
     oval_definition_id: str = None
+    oval_reference: str = None
     oval_definition: OvalDefinition = None
     messages: List[str] = field(default_factory=list)
     remediations: List[Remediation] = field(default_factory=list)

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -25,9 +25,7 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
         try:
             self.cpe_al_parser = CPEApplicabilityLanguageParser(self.root)
             self.platform_to_oval_cpe_id = self.cpe_al_parser.platform_to_oval_cpe_id
-            self.oval_definition_parser = OVALDefinitionParser(
-                self.root, self.platform_to_oval_cpe_id
-            )
+            self.oval_definition_parser = OVALDefinitionParser(self.root)
             self.oval_definitions = self.oval_definition_parser.get_oval_definitions()
             self.oval_cpe_definitions = self.oval_definition_parser.get_oval_cpe_definitions()
             self._load_cpe_platforms()

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -9,53 +9,89 @@ from .parsers import CPEApplicabilityLanguageParser, OVALDefinitionParser
 
 
 class OVALAndCPETreeBuilder:  # pylint: disable=R0902
-    def __init__(self, root, group_parser, profile_platforms):
+    def __init__(self, root, group_parser, profile_platforms, oval_definitions_and_results_sources):
         self.profile_platforms = profile_platforms
         self.root = root
         self.group_parser = group_parser
+        self.oval_definitions_and_results_sources = oval_definitions_and_results_sources
+        self.cpe_source = ""
         self.missing_oval_results = False
         self.cpe_al = True
-        self.oval_definitions = {}
-        self.oval_cpe_definitions = {}
+        self.reports_with_oval_definitions = None
         self.platform_to_oval_cpe_id = {}
         self.cpe_platforms = {}
+        self.dict_of_oval_cpe_definitions = {}
         self.load_oval_definitions()
 
     def load_oval_definitions(self):
         try:
-            self.cpe_al_parser = CPEApplicabilityLanguageParser(self.root)
-            self.platform_to_oval_cpe_id = self.cpe_al_parser.platform_to_oval_cpe_id
             self.oval_definition_parser = OVALDefinitionParser(self.root)
-            self.oval_definitions = self.oval_definition_parser.get_oval_definitions()
-            self.oval_cpe_definitions = self.oval_definition_parser.get_oval_cpe_definitions()
+            self.reports_with_oval_definitions = self.oval_definition_parser.get_oval_definitions()
+            self._determine_cpe_source()
+            self.dict_of_oval_cpe_definitions = self._get_dict_of_oval_cpe_definitions()
+            self.cpe_al_parser = CPEApplicabilityLanguageParser(
+                self.root, self.dict_of_oval_cpe_definitions
+            )
+            self.platform_to_oval_cpe_id = self.cpe_al_parser.platform_to_oval_cpe_id
             self._load_cpe_platforms()
         except MissingOVALResult as error:
             logging.warning((
-                "The given input doesn't contain OVAL results (\"%s\"),"
-                " OVAL details won't be shown in the report."), error)
-            if str(error) != "oval1":
-                self.missing_oval_results = True
+                "The given input doesn't contain OVAL results (\"%s\"), "
+                "OVAL details won't be shown in the report."), error)
+            self.missing_oval_results = True
+
+    def _determine_cpe_source(self):
+        source_id = set(self.reports_with_oval_definitions.keys()).difference(
+            self.oval_definitions_and_results_sources
+        )
+        if len(source_id) == 1:
+            self.cpe_source = source_id.pop()
+
+    def _get_dict_of_oval_cpe_definitions(self):
+        if self.cpe_source in self.reports_with_oval_definitions:
+            return self.reports_with_oval_definitions[self.cpe_source]
+        logging.warning((
+            "The given input does not contain a clear mapping of the OVAL definition used "
+            "for CPE checks. The results of the OVAL definition in the CPE checks could "
+            "be biased."
+        ))
+        all_oval_definition = {}
+        for report in self.reports_with_oval_definitions.values():
+            for id_definition, definition in report.items():
+                if id_definition not in all_oval_definition:
+                    all_oval_definition[id_definition] = definition
+                else:
+                    if definition.oval_tree.evaluate_tree() != "not evaluated":
+                        all_oval_definition[id_definition] = definition
+        return all_oval_definition
+
+    def _get_oval_definition_of_cpe(self, platform):
+        cpe_oval_id = self.platform_to_oval_cpe_id.get(platform)
+        return self.dict_of_oval_cpe_definitions.get(cpe_oval_id)
 
     def _load_cpe_platforms(self):
         try:
-            self.cpe_platforms = self.cpe_al_parser.get_cpe_platforms(self.oval_cpe_definitions)
+            self.cpe_platforms = self.cpe_al_parser.get_cpe_platforms()
             for platform in self.profile_platforms:
-                if platform in self.platform_to_oval_cpe_id:
-                    cpe_oval_id = self.platform_to_oval_cpe_id[platform]
-                    if cpe_oval_id in self.oval_cpe_definitions:
-                        oval_tree = self.oval_cpe_definitions[cpe_oval_id].oval_tree
-                        self.cpe_platforms[platform] = Platform(
-                            platform_id=platform,
-                            logical_test=LogicalTest(
-                                node_type="AND",
-                                children=[LogicalTest(
-                                    node_type="frac-ref",
-                                    value=cpe_oval_id,
-                                    oval_tree=oval_tree
-                                )],
-                            ),
-                            title="Profile platform",
-                        )
+                oval_definition = self._get_oval_definition_of_cpe(platform)
+                if oval_definition is None:
+                    logging.warning(
+                        "Platform (\"%s\") doesn't exist, Platform won't be shown in the report.",
+                        platform
+                    )
+                    continue
+                self.cpe_platforms[platform] = Platform(
+                    platform_id=platform,
+                    logical_test=LogicalTest(
+                        node_type="AND",
+                        children=[LogicalTest(
+                            node_type="frac-ref",
+                            value=oval_definition.definition_id,
+                            oval_tree=oval_definition.oval_tree
+                        )],
+                    ),
+                    title="Profile platform",
+                )
             self._evaluate_all_cpe_platforms()
         except ExceptionNoCPEApplicabilityLanguage:
             self.cpe_al = False
@@ -69,8 +105,8 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
         cpe_platform = platform.lstrip("#")
         if cpe_platform in self.platform_to_oval_cpe_id:
             cpe_oval_id = self.platform_to_oval_cpe_id[cpe_platform]
-        if cpe_oval_id in self.oval_cpe_definitions:
-            return self.oval_cpe_definitions[cpe_oval_id].oval_tree
+        if cpe_oval_id in self.dict_of_oval_cpe_definitions:
+            return self.dict_of_oval_cpe_definitions[cpe_oval_id].oval_tree
         if cpe_platform in self.cpe_platforms:
             return None
         logging.warning("There is no CPE check for the platform \"%s\".", platform)
@@ -98,13 +134,29 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
             if platform in group_platforms:
                 group_platforms.remove(platform)
 
+    def get_oval_definition(self, rule):
+        report = self.reports_with_oval_definitions.get(rule.oval_reference, None)
+        if report is not None:
+            return report.get(rule.oval_definition_id)
+        oval_def = None
+        for report in self.reports_with_oval_definitions.values():
+            if oval_def is not None and rule.oval_definition_id in report:
+                logging.warning(
+                    ("The given input contains the duplicate results of "
+                     "the OVAL definition (\"%s\")."),
+                    rule.oval_definition_id
+                )
+            if rule.oval_definition_id in report:
+                oval_def = report[rule.oval_definition_id]
+        return oval_def
+
     def insert_oval_and_cpe_trees_to_rules(self, rules):
         if self.missing_oval_results:
             return
 
         for rule in rules.values():
-            if rule.oval_definition_id in self.oval_definitions:
-                rule.oval_definition = self.oval_definitions[rule.oval_definition_id]
+            rule.oval_definition = self.get_oval_definition(rule)
+
             rule_group = self.group_parser.rule_to_group_id.get(rule.rule_id, "")
             group_platforms = self.group_parser.group_to_platforms.get(rule_group, [])
             self._remove_double_cpe_requirement(rule, group_platforms)

--- a/openscap_report/scap_results_parser/parsers/cpe_al_parser.py
+++ b/openscap_report/scap_results_parser/parsers/cpe_al_parser.py
@@ -9,11 +9,11 @@ TEXT_TO_BOOL = {"true": True, "false": False, "": False}
 
 
 class CPEApplicabilityLanguageParser:
-    def __init__(self, root):
+    def __init__(self, root, oval_cpe_definitions):
         self.root = root
         self.platform_to_oval_cpe_id = self.get_platform_to_oval_cpe_id_dict()
         self.full_text_parser = FullTextParser({})
-        self.oval_cpe_definitions = {}
+        self.oval_cpe_definitions = oval_cpe_definitions
 
     def get_platform_to_oval_cpe_id_dict(self):
         cpe_list = self.root.find(".//ds:component/cpe-dict:cpe-list", NAMESPACES)
@@ -69,9 +69,8 @@ class CPEApplicabilityLanguageParser:
                 logical_test.children.append(self.get_logical_test(child_logical_test_el))
         return logical_test
 
-    def get_cpe_platforms(self, oval_cpe_definitions):
+    def get_cpe_platforms(self):
         out = {}
-        self.oval_cpe_definitions = oval_cpe_definitions
         for platform, platform_el in self._get_cpe_platform_elements().items():
             title_el = platform_el.find(".//cpe-lang:title", NAMESPACES)
             title_str = ""

--- a/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
@@ -63,10 +63,10 @@ class OVALDefinitionParser:
         return definitions
 
     def get_oval_definitions(self):
-        return self._get_oval_definitions("oval0")
-
-    def get_oval_cpe_definitions(self):
-        return self._get_oval_definitions("oval1")
+        oval_definitions_by_reports = {}
+        for report_id in self.oval_trees_by_oval_reports:
+            oval_definitions_by_reports[report_id] = self._get_oval_definitions(report_id)
+        return oval_definitions_by_reports
 
     def _get_test_criteria(self, criterion):
         out = {"comment": criterion.get("comment")}

--- a/openscap_report/scap_results_parser/parsers/rule_parser.py
+++ b/openscap_report/scap_results_parser/parsers/rule_parser.py
@@ -146,6 +146,18 @@ class RuleParser():
             msg = "The OVAL graph of the rule as it was displayed before the fix was performed."
             rules[rule_id].messages.append(msg)
 
+    @staticmethod
+    def set_oval_definition_id_if_is_none(rule, check_name):
+        if rule.oval_definition_id is None:
+            rule.oval_definition_id = check_name
+
+    @staticmethod
+    def get_oval_check_href_name(rule_result_el):
+        check_ref = rule_result_el.find('.//xccdf:check/xccdf:check-content-ref', NAMESPACES)
+        if check_ref is None:
+            return None, None
+        return check_ref.get("href").lstrip("#"), check_ref.get("name")
+
     def _insert_rules_results(self, rules):
         rules_results = self.test_results.findall('.//xccdf:rule-result', NAMESPACES)
         for rule_result in rules_results:
@@ -153,6 +165,11 @@ class RuleParser():
             rules[rule_id].time = rule_result.get('time')
             rules[rule_id].result = rule_result.find('.//xccdf:result', NAMESPACES).text
             rules[rule_id].weight = float(rule_result.get('weight'))
+
+            rules[rule_id].oval_reference, check_name = self.get_oval_check_href_name(
+                rule_result
+            )
+            self.set_oval_definition_id_if_is_none(rules[rule_id], check_name)
 
             messages = rule_result.findall('.//xccdf:message', NAMESPACES)
             if messages is not None:

--- a/openscap_report/scap_results_parser/scap_results_parser.py
+++ b/openscap_report/scap_results_parser/scap_results_parser.py
@@ -62,13 +62,6 @@ class SCAPResultsParser():
             logging.debug(rule_id)
             logging.debug(rule)
 
-    @staticmethod
-    def _get_applicable_cpe_ids_for_machine(cpe_platforms_for_profile):
-        return [
-            cpe_id for cpe_id, applicable_for_machine in cpe_platforms_for_profile.items()
-            if applicable_for_machine
-        ]
-
     def _get_benchmark_element(self):
         benchmark_el = self.root.find(".//xccdf:Benchmark", NAMESPACES)
         if "Benchmark" in self.root.tag:
@@ -99,7 +92,7 @@ class SCAPResultsParser():
         oval_definitions_and_results_sources = self._get_oval_definition_references(rules)
         OVAL_and_CPE_tree_builder = OVALAndCPETreeBuilder(  # pylint: disable=C0103
             self.root, group_parser,
-            self._get_applicable_cpe_ids_for_machine(report.profile_info.cpe_platforms_for_profile),
+            report.profile_info.get_list_of_cpe_platforms_that_satisfy_evaluation_target(),
             oval_definitions_and_results_sources
         )
         OVAL_and_CPE_tree_builder.insert_oval_and_cpe_trees_to_rules(rules)

--- a/openscap_report/scap_results_parser/scap_results_parser.py
+++ b/openscap_report/scap_results_parser/scap_results_parser.py
@@ -75,6 +75,14 @@ class SCAPResultsParser():
             benchmark_el = self.root
         return benchmark_el
 
+    @staticmethod
+    def _get_oval_definition_references(rules):
+        references = []
+        for rule in rules.values():
+            if rule.oval_reference is not None:
+                references.append(rule.oval_reference)
+        return set(tuple(references))
+
     def parse_report(self):
         test_results_el = self.root.find('.//xccdf:TestResult', NAMESPACES)
         benchmark_el = self._get_benchmark_element()
@@ -88,10 +96,11 @@ class SCAPResultsParser():
 
         rule_parser = RuleParser(self.root, test_results_el, self.ref_values)
         rules = rule_parser.get_rules()
-
+        oval_definitions_and_results_sources = self._get_oval_definition_references(rules)
         OVAL_and_CPE_tree_builder = OVALAndCPETreeBuilder(  # pylint: disable=C0103
             self.root, group_parser,
-            self._get_applicable_cpe_ids_for_machine(report.profile_info.cpe_platforms_for_profile)
+            self._get_applicable_cpe_ids_for_machine(report.profile_info.cpe_platforms_for_profile),
+            oval_definitions_and_results_sources
         )
         OVAL_and_CPE_tree_builder.insert_oval_and_cpe_trees_to_rules(rules)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,7 +91,7 @@ def get_rules(file_path=None):
 
 def get_cpe_al_parser(file_path=PATH_TO_ARF):
     root = get_root(file_path)
-    return CPEApplicabilityLanguageParser(root)
+    return CPEApplicabilityLanguageParser(root, get_dummy_cpe_oval_definition())
 
 
 def get_dummy_cpe_oval_definition():

--- a/tests/unit_tests/test_cpe_al_parser.py
+++ b/tests/unit_tests/test_cpe_al_parser.py
@@ -4,7 +4,7 @@
 import pytest
 from lxml import etree
 
-from ..test_utils import get_cpe_al_parser, get_dummy_cpe_oval_definition
+from ..test_utils import get_cpe_al_parser
 
 
 @pytest.mark.unit_test
@@ -101,7 +101,6 @@ from ..test_utils import get_cpe_al_parser, get_dummy_cpe_oval_definition
 )
 def test_get_logical_test(str_xml_element, evaluation_result):
     parser = get_cpe_al_parser()
-    parser.oval_cpe_definitions = get_dummy_cpe_oval_definition()
     xml_element = etree.XML(
         f'<con xmlns:cpe-lang="http://cpe.mitre.org/language/2.0">{str_xml_element}</con>'
     )


### PR DESCRIPTION
This PR changes the approach of loading the OVAL results report and brings special logic to determine where is present the OVAL result report with the OVAL definitions that are used in the CPE dictionary and CPE AL. 

The OVAL result report element is selected according to the references in the rule results. The selected element is the one that is not referenced in the rule results. If multiple report elements are not referenced in the rule result, OVAL definitions for CPE are selected from all report elements. In the case of duplicate definitions, the first definition or the definition that has a result other than `not evaluated` is chosen.