### PR TITLE
Style adjustments of report

### DIFF
--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -201,3 +201,11 @@ footer {
     word-break: break-word;
     hyphens: auto;
 }
+
+.clickable-element {
+    text-decoration: underline dotted;
+}
+
+.clickable-element:hover {
+    text-decoration: underline;
+}

--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -209,3 +209,7 @@ footer {
 .clickable-element:hover {
     text-decoration: underline;
 }
+
+.remediation-clipboard-padding {
+    padding-left: 0px !important;
+}

--- a/openscap_report/report_generators/html_templates/js/interactive_script.js
+++ b/openscap_report/report_generators/html_templates/js/interactive_script.js
@@ -120,6 +120,10 @@ function show_rule_detail(self) { // eslint-disable-line no-unused-vars
     element_to_show.classList.toggle('pf-m-expanded');
 }
 
+function show_rule_detail_after_click_on_rule_title(self) { // eslint-disable-line no-unused-vars
+    show_rule_detail(self.parentElement.previousSibling.firstChild);
+}
+
 const selector = ".pf-c-clipboard-copy__text";
 document.querySelectorAll("#copy").forEach(el => el.addEventListener('click', () => {
     const el_with_text = el.parentElement.parentElement.parentElement.querySelector(selector);

--- a/openscap_report/report_generators/html_templates/remedations.html
+++ b/openscap_report/report_generators/html_templates/remedations.html
@@ -5,7 +5,7 @@
 <tr role="row">
     <td colspan="2" role="cell">
         <details>
-            <summary>Remediation {{ remediation.get_type() }}</summary>
+            <summary><span class="clickable-element">Remediation {{ remediation.get_type() }}</span></summary>
             <table class="pf-c-table pf-m-grid-md" role="grid">
                 <thead>
                     <tr role="row">

--- a/openscap_report/report_generators/html_templates/remedations.html
+++ b/openscap_report/report_generators/html_templates/remedations.html
@@ -34,7 +34,18 @@
                     {% endif %}
                 </tbody>
             </table>
-            <pre>{{ remediation.fix | e }}</pre>
+            <div class="pf-c-clipboard-copy pf-m-inline pf-m-block remediation-clipboard-padding">
+                <span class="pf-c-clipboard-copy__actions">
+                  <span class="pf-c-clipboard-copy__actions-item">
+                    <button id="copy" class="pf-c-button pf-m-plain" type="button" aria-label="Copy remediation to clipboard">
+                      <i class="fas fa-copy" aria-hidden="true"></i> Copy remediation
+                    </button>
+                  </span>
+                </span>
+                <span class="pf-c-clipboard-copy__text">
+                    <pre>{{ remediation.fix | e }}</pre>
+                </span>
+            </div>
         </details>
     </td>
 </tr>

--- a/openscap_report/report_generators/html_templates/rules_overview.html
+++ b/openscap_report/report_generators/html_templates/rules_overview.html
@@ -41,8 +41,11 @@
             </td>
 
             <td role="cell" id="title_{{ rule.rule_id }}" class="rule-title" data-label="Rule">
-                <span class="pf-c-table__text">{{ rule_title }}</span>
+                <button class="pf-c-button pf-m-plain clickable-element" onclick="show_rule_detail_after_click_on_rule_title(this);">
+                    <span class="pf-c-table__text">{{ rule_title }}</span>
+                </button>
             </td>
+
             <td role="cell" class="rule-severity" data-label="Severity">
                 {% if rule.result not in ("pass", "fixed") and rule.severity == "low" %}
                 <span class="pf-c-label pf-m-blue">

--- a/openscap_report/report_generators/html_templates/search_input.html
+++ b/openscap_report/report_generators/html_templates/search_input.html
@@ -12,8 +12,8 @@
     <div class="pf-c-accordion__expanded-content" style="display: none;">
         <div class="pf-c-accordion__expanded-content-body">
             <br>
-            <h3 class="pf-c-title pf-m-md">Advanced search options</h3>
-            Search by result:
+            <h3 class="pf-c-title pf-m-md">Advanced filtering options</h3>
+            Filter by result:
             <div class="container">
                 <label class="pf-c-check" for="checkbox-result-pass">
                     <input class="pf-c-check__input" type="checkbox" id="checkbox-result-pass" onchange="toggle_rules('result', 'pass');" checked/>
@@ -56,7 +56,7 @@
                     <span class="pf-c-check__label">Unknown</span>
                 </label>
             </div>
-            Search by severity:
+            Filter by severity:
             <div class="container">
                 <label class="pf-c-check" for="checkbox-severity-high">
                     <input class="pf-c-check__input" type="checkbox" id="checkbox-severity-high" onchange="toggle_rules('severity', 'high');" checked/>


### PR DESCRIPTION
This PR brings improvements to the style of the report, such as:

* Improves wording in the filtering section,
* Underlines the clickable element of the remediation,
* Adds a copy button to the clipboard fix of remediation,
* Allows you to click on the rule title in the rules overview to collapse rule detail. (On hover element is underlined) 

Remediation example:
![remdiation_example](https://user-images.githubusercontent.com/26072444/224754308-980607a1-6b2c-4e78-b5a3-96800d4d8841.png)

Rule overview:
![image](https://user-images.githubusercontent.com/26072444/225003683-cc724def-29b5-4aff-aa43-8725a07691da.png)
