### PR TITLE
Add collected OVAL object messages

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -608,6 +608,37 @@ function generate_OVAL_state(test_info, div) {
     table.appendChild(get_table_body(objects));
 }
 
+
+function generate_OVAL_error_message(test_info, div) {
+    div.appendChild(BR.cloneNode());
+    div.appendChild(BR.cloneNode());
+
+    const alert_div = DIV.cloneNode();
+    alert_div.className = "pf-c-alert pf-m-danger pf-m-inline";
+    div.appendChild(alert_div);
+
+    const icon_div = DIV.cloneNode();
+    icon_div.className = "pf-c-alert__icon";
+    alert_div.appendChild(icon_div);
+
+    const icon = ICON.cloneNode();
+    icon.className = "fas fa-fw fa-exclamation-circle";
+    icon.setAttribute("aria-hidden", "true");
+    icon_div.appendChild(icon);
+
+    const title_div = DIV.cloneNode();
+    title_div.className = "pf-c-alert__title";
+    title_div.textContent = test_info.oval_object.message.level;
+    alert_div.appendChild(title_div);
+
+    const description_div = DIV.cloneNode();
+    description_div.className = "pf-c-alert__description";
+    description_div.textContent = test_info.oval_object.message.text;
+    alert_div.appendChild(description_div);
+
+    div.appendChild(BR.cloneNode());
+}
+
 function get_OVAL_test_info(test_info) {
     const div = DIV.cloneNode();
     div.className = "pf-c-accordion__expanded-content-body";
@@ -617,6 +648,10 @@ function get_OVAL_test_info(test_info) {
     }
     if (test_info.check_existence && test_info.check_existence in CHECK_EXISTENCE_ATTRIBUTE_TO_TEXT) {
         div.appendChild(get_label("pf-m-cyan", `Check existence atribute: ${test_info.check_existence}\u00A0`, undefined, "", "", CHECK_EXISTENCE_ATTRIBUTE_TO_TEXT[test_info.check_existence]));
+    }
+
+    if (test_info.oval_object.message !== null) {
+        generate_OVAL_error_message(test_info, div);
     }
 
     generate_OVAL_object(test_info, div);

--- a/openscap_report/scap_results_parser/data_structures/__init__.py
+++ b/openscap_report/scap_results_parser/data_structures/__init__.py
@@ -7,7 +7,7 @@ from .group import Group
 from .identifier import Identifier
 from .oval_definition import OvalDefinition
 from .oval_node import OvalNode
-from .oval_object import OvalObject
+from .oval_object import OvalObject, OvalObjectMessage
 from .oval_reference import OvalReference
 from .oval_result_eval import (EMPTY_RESULT, FULL_RESULT_TO_SHORT_RESULT,
                                SHORT_RESULT_TO_FULL_RESULT, OvalResult)

--- a/openscap_report/scap_results_parser/data_structures/oval_object.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_object.py
@@ -5,9 +5,16 @@ from dataclasses import asdict, dataclass, field
 
 
 @dataclass
+class OvalObjectMessage:
+    level: str
+    text: str
+
+
+@dataclass
 class OvalObject:
     object_id: str
     flag: str = ""
+    message: OvalObjectMessage = None
     object_type: str = ""
     object_data: list[dict[str, str]] = field(default_factory=list)
 

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -1,7 +1,8 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from ..data_structures import OvalObject
+from ..data_structures import OvalObject, OvalObjectMessage
+from ..namespaces import NAMESPACES
 from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 MAX_MESSAGE_LEN = 99
@@ -59,12 +60,22 @@ class OVALObjectParser:
                 item[key] = element.text
         return item
 
+    def _get_oval_message(self, xml_collected_object):
+        message = xml_collected_object.find(".//oval-characteristics:message", NAMESPACES)
+        if message is not None:
+            return OvalObjectMessage(message.get("level", ""), message.text)
+        return None
+
     def _get_collected_objects_info(self, xml_collected_object, xml_object):
         object_dict = {
             "object_id": xml_collected_object.get('id'),
             "flag": xml_collected_object.get('flag'),
             "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
         }
+        message = self._get_oval_message(xml_collected_object)
+        if message is not None:
+            object_dict["message"] = message
+
         if len(xml_collected_object) == 0:
             object_dict["object_data"] = [self._get_object_items(xml_object, xml_collected_object)]
         else:


### PR DESCRIPTION
This PR adds a message of the collected OVAL object. Usually, this message explains why the OVAL test ended with an error result.

Example:
![image](https://user-images.githubusercontent.com/26072444/225881841-4522fa98-3136-49ce-91b5-d44cbb2f174b.png)
