### PR TITLE
Separate packit job for release in EPEL 8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,8 @@ files_to_sync:
       dest: plans/
     - src: .fmf/
       dest: .fmf/
+    - src: tests/
+      dest: tests/
 
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: openscap-report

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,8 +34,15 @@ actions:
 jobs:
 - job: propose_downstream
   trigger: release
+  identifier: release-rawhide
   dist_git_branches:
     - fedora-rawhide
+
+- job: propose_downstream
+  trigger: release
+  identifier: release-epel8
+  specfile_path: spec/rhel8/openscap-report.spec
+  dist_git_branches:
     - epel-8
 
 - job: tests


### PR DESCRIPTION
The main purpose of this PR is to create a separate EPEL 8 release job.  Additionally, this PR contains test synchronization.