### PR TITLE
Show references and identifier as plain text when href is unavailable

### DIFF
--- a/openscap_report/report_generators/html_templates/rule_detail.html
+++ b/openscap_report/report_generators/html_templates/rule_detail.html
@@ -126,7 +126,7 @@
                         {%- if identifier.href -%}
                             <a href="{{ identifier.href | replace('&', ';') }}">{{ identifier.text }}</a>
                         {%- else -%}
-                            <a href="identifier_href_not_found">{{ identifier.text }}</a>
+                            <span>{{ identifier.text }}</span>
                         {%- endif -%}
                         {{- ", " if not loop.last else "" -}}
                         {%- endfor %}
@@ -147,7 +147,7 @@
                         {%- if reference.href -%}
                             <a href="{{ reference.href | replace('&', ';') }}">{{ reference.text }}</a>
                         {%- else -%}
-                            <a href="reference_href_not_found">{{ reference.text }}</a>
+                            <span>{{ reference.text }}</span>
                         {%- endif -%}
                         {{- ", " if not loop.last else "" -}}
                         {%- endfor -%}


### PR DESCRIPTION
This PR uses a span element instead of a link element when the href is unavailable.

Fixes: #172
