### PR TITLE
Disable scrollbar in rule detail

### DIFF
--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -225,3 +225,9 @@ footer {
 .remediation-clipboard-padding {
     padding-left: 0px !important;
 }
+
+@media screen and (max-width: 992px) {
+    .disable-scrollbar-for-low-resolution {
+        max-height: unset !important;
+    }
+}

--- a/openscap_report/report_generators/html_templates/rules_overview.html
+++ b/openscap_report/report_generators/html_templates/rules_overview.html
@@ -96,7 +96,7 @@
                 {% endif %}
             </td>
         </tr>
-        <tr class="pf-c-table__expandable-row" role="row">
+        <tr class="pf-c-table__expandable-row disable-scrollbar-for-low-resolution" role="row">
             <td role="cell" colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     {% include 'rule_detail.html' %}


### PR DESCRIPTION
This PR relates to issue #173. The problem occurs when the window width is less than 900px because the report layout changes and the rule detail becomes scrollable.

Specifically, Firefox has user-manageable settings for displaying scrollbars, and Webkit for scrollbars is not implemented in Firefox. This makes it difficult to customize the scrollbar. Therefore, I decided to disable scrolling for the rule detail when the window width is small. 