### PR TITLE
Change RedHat fonts to weak dependency

### DIFF
--- a/openscap-report.spec
+++ b/openscap-report.spec
@@ -19,8 +19,8 @@ BuildRequires:  python3-sphinx_rtd_theme
 Provides:       bundled(patternfly) = 4
 
 Requires:       python3-lxml
-Requires:       redhat-display-fonts
-Requires:       redhat-text-fonts
+Recommends:     redhat-display-fonts
+Recommends:     redhat-text-fonts
 
 %global _description %{expand:
 This package provides a command-line tool for generating

--- a/openscap_report/report_generators/html.py
+++ b/openscap_report/report_generators/html.py
@@ -45,7 +45,7 @@ class HTMLReportGenerator(ReportGenerator):
         if "RedHat" in relative_path:
             real_path = Path(relative_path)
         if not real_path.exists():
-            logging.warning("Please, install font: %s", real_path.name)
+            logging.info("Please, install font: %s", real_path.name)
             return Markup("NO-FONT-DATA")
         base64_data = None
         with open(real_path, "rb") as file_data:

--- a/spec/rhel8/openscap-report.spec
+++ b/spec/rhel8/openscap-report.spec
@@ -20,6 +20,8 @@ Provides:       bundled(patternfly) = 4
 
 Requires:       python38-lxml
 Requires:       python38-jinja2
+Recommends:     redhat-display-fonts
+Recommends:     redhat-text-fonts
 
 %{?python_enable_dependency_generator}
 


### PR DESCRIPTION
This PR changes the requirement of redhat fonts as weak dependency and changes the logging severity of missing fonts warning.

Fixes: #184  