### PR TITLE
Rename field Result explained to Class explained

### DIFF
--- a/openscap_report/report_generators/html_templates/oval_definition_detail.html
+++ b/openscap_report/report_generators/html_templates/oval_definition_detail.html
@@ -41,7 +41,7 @@
     </td>
 </tr>
 <tr role="row">
-    <th class="pf-m-fit-content" role="rowheader" scope="row"><b>Result explained:</b></th>
+    <th class="pf-m-fit-content" role="rowheader" scope="row"><b>Class explained:</b></th>
     <td role="cell">
         <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
         <p class="pf-c-table__text">{{ rule.oval_definition.get_oval_class_description() }}</p></div></div>


### PR DESCRIPTION
This PR renames the Result explained field to Class explained. To avoid confusion in this field.