### PR TITLE
Explain the calculation of the score

### DIFF
--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -234,6 +234,11 @@ footer {
     max-width: fit-content;
 }
 
+.tooltip-box-score-position {
+    top: 8px !important;
+    left: 102px !important;
+}
+
 .clickable-element {
     text-decoration: underline dotted;
 }

--- a/openscap_report/report_generators/html_templates/template_report.html
+++ b/openscap_report/report_generators/html_templates/template_report.html
@@ -67,8 +67,14 @@
 {% endif %}
 </div>
 <br>
+<div class="tooltip-wrapper" style="position: relative;">
+    <h2 class="pf-c-title pf-m-2xl">Score&nbsp;<i class="pf-icon pf-icon-help" aria-hidden="true"></i></h2>
+    <div class="pf-c-tooltip pf-m-right-top tooltip-box-right-side tooltip-box-score-position" role="tooltip">
+        <div class="pf-c-tooltip__arrow"></div>
+        <div class="pf-c-tooltip__content tooltip__content-width">{{ report.scan_result.get_explanation_of_score_computation() }}</div>
+    </div>
+</div>
 
-<h2 class="pf-c-title pf-m-2xl">Score</h2>
 {% include 'score_bar.html' %}
 <br>
 

--- a/openscap_report/scap_results_parser/data_structures/result_of_scan.py
+++ b/openscap_report/scap_results_parser/data_structures/result_of_scan.py
@@ -18,6 +18,7 @@ SCAN_JSON_KEYS = [
     "start_time",
     "end_time",
     "test_system",
+    "score_system",
     "score",
     "score_max",
 ]
@@ -38,6 +39,7 @@ class ResultOfScan:  # pylint: disable=R0902
     start_time: str = ""
     end_time: str = ""
     test_system: str = ""
+    score_system: str = ""
     score: float = 0.0
     score_max: float = 0.0
 

--- a/openscap_report/scap_results_parser/data_structures/result_of_scan.py
+++ b/openscap_report/scap_results_parser/data_structures/result_of_scan.py
@@ -23,6 +23,32 @@ SCAN_JSON_KEYS = [
     "score_max",
 ]
 
+SCORE_COMPUTATION_EXPLANATIONS = {
+    "urn:xccdf:scoring:default": (
+        "The default model score computation algorithm simply computes a normalized weighted sum "
+        "at each tree node, omitting Rules and Groups that are not selected, and Groups that have "
+        "no selected Rules under them. (Visualization of Groups in report is not implemented yet.)"
+    ),
+    "urn:xccdf:scoring:flat": (
+        "The flat model simply computes the sum of the weights for the Rules that passed "
+        "as the score, and the sum of the weights of all the applicable Rules as "
+        "the maximum possible score. This model is simple and easy to compute, "
+        "but scores between different target systems may not be directly comparable "
+        "because the maximum score can vary."
+    ),
+    "urn:xccdf:scoring:flat-unweighted": (
+        "The flat unweighted model simply computes the sum of the Rules that passed as the score, "
+        "and the sum of all the applicable Rules as the maximum possible score. This model is "
+        "simple and easy to compute, but scores between different target systems may not be "
+        "directly comparable because the maximum score can vary."
+    ),
+    "urn:xccdf:scoring:absolute": (
+        "The absolute model gives a score of 1 only when all applicable rules "
+        "in the benchmark pass. It is computed by applying the Flat Model "
+        "and returning 1 if s==m, and 0 otherwise."
+    )
+}
+
 
 @dataclass
 class ResultOfScan:  # pylint: disable=R0902
@@ -45,3 +71,6 @@ class ResultOfScan:  # pylint: disable=R0902
 
     def as_dict(self):
         return asdict(self)
+
+    def get_explanation_of_score_computation(self):
+        return SCORE_COMPUTATION_EXPLANATIONS[self.score_system]

--- a/openscap_report/scap_results_parser/parsers/scan_result_parser.py
+++ b/openscap_report/scap_results_parser/parsers/scan_result_parser.py
@@ -35,6 +35,7 @@ class ScanResultParser:
             "start_time": self.test_results_el.get("start-time"),
             "end_time": self.test_results_el.get("end-time"),
             "test_system": self.test_results_el.get("test-system"),
+            "score_system": score_el.get("system"),
             "score": float(score_el.text),
             "score_max": float(score_el.get("maximum")),
             "benchmark_url": self.benchmark_el.get("href"),


### PR DESCRIPTION
This PR adds a tooltip that explains the computation of the score in the report. 

Fixes: #163
