### PR TITLE
Fix deprecation warning

### DIFF
--- a/openscap_report/__init__.py
+++ b/openscap_report/__init__.py
@@ -1,14 +1,11 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from importlib.metadata import PackageNotFoundError, version
 from os import path
-
-from pkg_resources import DistributionNotFound, get_distribution
 
 DISTRIBUTION_NAME = "openscap-report"
 try:
-    distribution = get_distribution(DISTRIBUTION_NAME)
-except DistributionNotFound:
+    __version__ = version(DISTRIBUTION_NAME)
+except PackageNotFoundError:
     __version__ = f"Version is unavailable. Please install {DISTRIBUTION_NAME}!"
-else:
-    __version__ = distribution.version


### PR DESCRIPTION
This PR fixes:
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html


Reproducer with `tox`:
```
diff --git a/tox.ini b/tox.ini
index 8d55872..5431db5 100644
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands =
         py.test --cov=openscap_report --cov-append --cov-report=term-missing -m "not integration_test"
         py.test --cov-report=term-missing -m "not unit_test"
 deps =
+    setuptools>=67.6.1
     pytest
     pytest-cov
     jsonschema

```
Fixes: #203 