### PR TITLE
Fix empty Value property value

### DIFF
--- a/openscap_report/scap_results_parser/scap_results_parser.py
+++ b/openscap_report/scap_results_parser/scap_results_parser.py
@@ -52,7 +52,7 @@ class SCAPResultsParser():
 
     def _get_ref_values(self):
         return {
-            ref_value.get("idref"): ref_value.text
+            ref_value.get("idref"): ref_value.text if ref_value.text is not None else ""
             for ref_value in self.root.findall('.//xccdf:set-value', NAMESPACES)
         }
 


### PR DESCRIPTION
This PR fixes crashes caused by empty values in the Value component. It is represented as `None` instead of an empty string in the lxml parser. The value of the Value component that was used during the scan is obtained from the `set-value` elements. In this case, it represents a self-closing `set-value` tag.  

The ID of the Value component that caused the problem is `xccdf_org.ssgproject.content_value_var_pam_wheel_group_for_su`. 

Fixes: #207 
