### PR TITLE
Rework the OVAL test details

### DIFF
--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -256,3 +256,9 @@ footer {
         max-height: unset !important;
     }
 }
+
+.oval-object-background {
+    background-color: var(--pf-global--BorderColor--100);
+    padding: 5px;
+    border-radius: 5px;
+}

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -90,6 +90,7 @@ const COL = document.createElement("td");
 const HEADER_COL = document.createElement("th");
 
 const P = document.createElement("p");
+const H1 = document.createElement("h1");
 
 const BR = document.createElement("br");
 const B = document.createElement("b");
@@ -349,6 +350,7 @@ function render_OVAL_test(node_data) {
     div.className = "pf-c-tree-view__node-container";
     div.setAttribute("id", info_id);
     div.style.display = "none";
+    div.className = "oval-object-background";
     div.setAttribute("aria-label", "OVAL test info");
     node_content.appendChild(div);
 
@@ -563,7 +565,7 @@ function get_table_body(objects) {
         const cols_fragment = document.createDocumentFragment();
         for (const key in object) {
             const clone_of_col = col.cloneNode();
-            clone_of_col.setAttribute("data-label", key);
+            clone_of_col.setAttribute("data-label", format_header_item(key));
             if(object[key] instanceof HTMLElement) {
                 clone_of_col.appendChild(object[key]);
             } else {
@@ -577,23 +579,18 @@ function get_table_body(objects) {
     return tbody;
 }
 
-function get_info_paragraf(test_info) {
-    const info_paragraf = P.cloneNode();
-    if (test_info.oval_object.flag == "complete") {
-        info_paragraf.textContent ='Following items have been found on the system: ';
-    } else {
-        info_paragraf.textContent ='No items have been found conforming to the following objects: ';
-        info_paragraf.appendChild(BR.cloneNode());
+function get_oval_object_info_heading(test_info) {
+    const div = DIV.cloneNode();
+    const h1 = H1.cloneNode();
+    h1.textContent ='OVAL object definition: ';
+    h1.className = "pf-c-title pf-m-lg";
+    div.appendChild(h1);
 
-        let bold_text = B.cloneNode();
-        bold_text.textContent = test_info.oval_object.object_id;
-        info_paragraf.appendChild(bold_text);
-        info_paragraf.appendChild(document.createTextNode(" of type "));
-        bold_text = B.cloneNode();
-        bold_text.textContent = test_info.oval_object.object_type;
-        info_paragraf.appendChild(bold_text);
-    }
-    return info_paragraf;
+    div.appendChild(get_label("pf-m-blue", `OVAL object ID: ${test_info.oval_object.object_id}\u00A0`, undefined, "", "", test_info.oval_object.comment));
+    div.appendChild(get_label("pf-m-blue", `OVAL object type: ${test_info.oval_object.object_type}\u00A0`));
+    div.appendChild(get_label("pf-m-blue", `Flag: ${test_info.oval_object.flag}\u00A0`));
+
+    return div;
 }
 
 function generate_OVAL_object(test_info, div) {
@@ -602,21 +599,27 @@ function generate_OVAL_object(test_info, div) {
         console.error("Error: The test information has no oval objects.");
         return;
     }
-    div.appendChild(get_info_paragraf(test_info));
+    div.appendChild(get_oval_object_info_heading(test_info));
     const table_div = DIV.cloneNode();
     table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
     div.appendChild(table_div);
-    const table = TABLE.cloneNode();
-    table.className = "pf-c-table pf-m-compact pf-m-grid-md";
-    table.setAttribute("role", "grid");
-    table_div.appendChild(table);
 
-    const objects = [];
-    for (const data of test_info.oval_object.object_data) {
-        objects.push(filter_object(data, test_info.oval_object));
+    for (const [key, value] of Object.entries(test_info.oval_object.object_data.pop())) { // eslint-disable-line array-element-newline
+        const h1 = H1.cloneNode();
+        h1.textContent = `Element ${key}:`;
+        h1.className = "pf-c-title pf-m-md";
+        table_div.appendChild(h1);
+
+        const table = TABLE.cloneNode();
+        table.className = "pf-c-table pf-m-compact pf-m-grid-md";
+        table.setAttribute("role", "grid");
+        table_div.appendChild(table);
+
+        const objects = [];
+        objects.push(filter_object(value, test_info.oval_object));
+        table.appendChild(get_table_header(objects));
+        table.appendChild(get_table_body(objects));
     }
-    table.appendChild(get_table_header(objects));
-    table.appendChild(get_table_body(objects));
 }
 
 function get_OVAL_state_labels(oval_state) {

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -89,7 +89,6 @@ const ROW = document.createElement("tr");
 const COL = document.createElement("td");
 const HEADER_COL = document.createElement("th");
 
-const P = document.createElement("p");
 const H1 = document.createElement("h1");
 
 const BR = document.createElement("br");
@@ -579,16 +578,18 @@ function get_table_body(objects) {
     return tbody;
 }
 
-function get_oval_object_info_heading(test_info) {
+function get_OVAL_object_info_heading(oval_object) {
     const div = DIV.cloneNode();
     const h1 = H1.cloneNode();
-    h1.textContent ='OVAL object definition: ';
+    h1.textContent ='OVAL Object definition: ';
     h1.className = "pf-c-title pf-m-lg";
+    div.appendChild(BR.cloneNode());
     div.appendChild(h1);
 
-    div.appendChild(get_label("pf-m-blue", `OVAL object ID: ${test_info.oval_object.object_id}\u00A0`, undefined, "", "", test_info.oval_object.comment));
-    div.appendChild(get_label("pf-m-blue", `OVAL object type: ${test_info.oval_object.object_type}\u00A0`));
-    div.appendChild(get_label("pf-m-blue", `Flag: ${test_info.oval_object.flag}\u00A0`));
+
+    div.appendChild(get_label("pf-m-blue", `OVAL Object ID: ${oval_object.object_id}\u00A0`, undefined, "", "", oval_object.comment));
+    div.appendChild(get_label("pf-m-blue", `OVAL Object type: ${oval_object.object_type}\u00A0`));
+    div.appendChild(get_label("pf-m-blue", `Flag: ${oval_object.flag}\u00A0`));
 
     return div;
 }
@@ -596,15 +597,15 @@ function get_oval_object_info_heading(test_info) {
 function generate_OVAL_object(test_info, div) {
     if (test_info.oval_object === undefined) {
         // eslint-disable-next-line no-console
-        console.error("Error: The test information has no oval objects.");
+        console.error("Error: The test information has no OVAL Objects.");
         return;
     }
-    div.appendChild(get_oval_object_info_heading(test_info));
+    div.appendChild(get_OVAL_object_info_heading(test_info.oval_object));
     const table_div = DIV.cloneNode();
     table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
     div.appendChild(table_div);
 
-    for (const [key, value] of Object.entries(test_info.oval_object.object_data.pop())) { // eslint-disable-line array-element-newline
+    for (const [key, value] of Object.entries(test_info.oval_object.object_data)) { // eslint-disable-line array-element-newline
         const h1 = H1.cloneNode();
         h1.textContent = `Element ${key}:`;
         h1.className = "pf-c-title pf-m-md";
@@ -622,36 +623,49 @@ function generate_OVAL_object(test_info, div) {
     }
 }
 
-function get_OVAL_state_labels(oval_state) {
+function get_OVAL_state_heading() {
     const div = DIV.cloneNode();
-    const text = P.cloneNode();
-    text.textContent ='This is expected state of OVAL object: ';
-    text.appendChild(BR.cloneNode());
-
-    div.appendChild(text);
-    div.appendChild(get_label("", `${oval_state.state_id}\u00A0`, undefined, "", "", oval_state.comment));
+    div.appendChild(BR.cloneNode());
+    const h1 = H1.cloneNode();
+    h1.textContent ='OVAL State definitions: ';
+    h1.className = "pf-c-title pf-m-lg";
+    div.appendChild(h1);
     return div;
 }
 
-function generate_OVAL_state(test_info, div) {
-    if (test_info.oval_state === null) {
+function get_OVAL_state_info(oval_state) {
+    const div = DIV.cloneNode();
+
+    div.appendChild(get_label("pf-m-blue", `OVAL State ID: ${oval_state.state_id}\u00A0`, undefined, "", "", oval_state.comment));
+    return div;
+}
+
+function generate_OVAL_state(oval_state, div) {
+    if (oval_state === null) {
         return;
     }
-    div.appendChild(BR.cloneNode());
-    div.appendChild(get_OVAL_state_labels(test_info.oval_state));
+    div.appendChild(get_OVAL_state_info(oval_state));
     const table_div = DIV.cloneNode();
     table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
     div.appendChild(table_div);
-    const table = TABLE.cloneNode();
-    table.className = "pf-c-table pf-m-compact pf-m-grid-md";
-    table.setAttribute("role", "grid");
-    table_div.appendChild(table);
 
-    const objects = [];
-    objects.push(filter_object(test_info.oval_state.state_data, test_info.oval_state));
+    for (const [key, value] of Object.entries(oval_state.state_data)) { // eslint-disable-line array-element-newline
+        const h1 = H1.cloneNode();
+        h1.textContent = `Element ${key}:`;
+        h1.className = "pf-c-title pf-m-md";
+        table_div.appendChild(h1);
 
-    table.appendChild(get_table_header(objects));
-    table.appendChild(get_table_body(objects));
+        const table = TABLE.cloneNode();
+        table.className = "pf-c-table pf-m-compact pf-m-grid-md";
+        table.setAttribute("role", "grid");
+        table_div.appendChild(table);
+
+        const objects = [];
+        objects.push(filter_object(value, oval_state));
+        table.appendChild(get_table_header(objects));
+        table.appendChild(get_table_body(objects));
+    }
+    div.appendChild(BR.cloneNode());
 }
 
 
@@ -701,7 +715,14 @@ function get_OVAL_test_info(test_info) {
     }
 
     generate_OVAL_object(test_info, div);
-    generate_OVAL_state(test_info, div);
+
+    if (test_info.oval_states.length > 0) {
+        div.appendChild(get_OVAL_state_heading());
+    }
+
+    for (const oval_state of test_info.oval_states) {
+        generate_OVAL_state(oval_state, div);
+    }
     return div;
 }
 

--- a/openscap_report/scap_results_parser/data_structures/oval_object.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_object.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List
+from typing import Dict
 
 
 @dataclass
@@ -18,7 +18,7 @@ class OvalObject:
     message: OvalObjectMessage = None
     comment: str = ""
     object_type: str = ""
-    object_data: List[Dict[str, str]] = field(default_factory=list)
+    object_data: Dict[str, str] = field(default_factory=dict)
 
     def as_dict(self):
         return asdict(self)

--- a/openscap_report/scap_results_parser/data_structures/oval_object.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_object.py
@@ -16,6 +16,7 @@ class OvalObject:
     object_id: str
     flag: str = ""
     message: OvalObjectMessage = None
+    comment: str = ""
     object_type: str = ""
     object_data: List[Dict[str, str]] = field(default_factory=list)
 

--- a/openscap_report/scap_results_parser/data_structures/oval_test.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_test.py
@@ -1,7 +1,8 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
+from typing import List
 
 from .oval_object import OvalObject
 from .oval_state import OvalState
@@ -15,7 +16,7 @@ class OvalTest:
     test_type: str = ""
     comment: str = ""
     oval_object: OvalObject = None
-    oval_state: OvalState = None
+    oval_states: List[OvalState] = field(default_factory=list)
 
     def as_dict(self):
         return asdict(self)

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -8,12 +8,15 @@ from .exceptions import ExceptionNoCPEApplicabilityLanguage, MissingOVALResult
 from .parsers import CPEApplicabilityLanguageParser, OVALDefinitionParser
 
 
-class OVALAndCPETreeBuilder:  # pylint: disable=R0902
-    def __init__(self, root, group_parser, profile_platforms, oval_definitions_and_results_sources):
+class OVALAndCPETreeBuilder:  # pylint: disable=R0902, R0913
+    def __init__(self, root, group_parser, profile_platforms,
+                 oval_definitions_and_results_sources, oval_var_id_to_value_id, ref_values):
         self.profile_platforms = profile_platforms
         self.root = root
         self.group_parser = group_parser
         self.oval_definitions_and_results_sources = oval_definitions_and_results_sources
+        self.oval_var_id_to_value_id = oval_var_id_to_value_id
+        self.ref_values = ref_values
         self.cpe_source = ""
         self.missing_oval_results = False
         self.cpe_al = True
@@ -25,7 +28,9 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902
 
     def load_oval_definitions(self):
         try:
-            self.oval_definition_parser = OVALDefinitionParser(self.root)
+            self.oval_definition_parser = OVALDefinitionParser(
+                self.root, self.oval_var_id_to_value_id, self.ref_values
+            )
             self.reports_with_oval_definitions = self.oval_definition_parser.get_oval_definitions()
             self._determine_cpe_source()
             self.dict_of_oval_cpe_definitions = self._get_dict_of_oval_cpe_definitions()

--- a/openscap_report/scap_results_parser/parsers/__init__.py
+++ b/openscap_report/scap_results_parser/parsers/__init__.py
@@ -8,7 +8,7 @@ from .oval_definition_parser import OVALDefinitionParser
 from .oval_object_parser import OVALObjectParser
 from .oval_result_parser import OVALResultParser
 from .oval_state_parser import OVALStateParser
-from .oval_test_info_parser import OVALTestInfoParser
+from .oval_test_parser import OVALTestParser
 from .profile_info_parser import ProfileInfoParser
 from .remediation_parser import RemediationParser
 from .report_parser import ReportParser

--- a/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
@@ -8,9 +8,9 @@ from .oval_result_parser import OVALResultParser
 
 
 class OVALDefinitionParser:
-    def __init__(self, root):
+    def __init__(self, root, oval_var_id_to_value_id, ref_values):
         self.root = root
-        self.oval_result_parser = OVALResultParser(self.root)
+        self.oval_result_parser = OVALResultParser(self.root, oval_var_id_to_value_id, ref_values)
         self.oval_trees_by_oval_reports = self.oval_result_parser.get_oval_trees_by_oval_reports()
 
         self.oval_reports = self.oval_result_parser.oval_reports

--- a/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
@@ -1,0 +1,62 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
+
+
+class OVALEndpointInformation:
+    def __init__(self, oval_var_id_to_value_id, ref_values):
+        self.oval_var_id_to_value_id = oval_var_id_to_value_id
+        self.ref_values = ref_values
+
+    def _get_oval_var_referenced_value(self, var_id, ids_of_oval_variable):
+        value_id = self.oval_var_id_to_value_id.get(var_id, "")
+        value = self.ref_values.get(value_id, var_id)
+        if value == var_id:
+            ids_of_oval_variable.append(var_id)
+        return value
+
+    def _parse_attributes(
+        self, id_in_items_of_test_property, element, element_dict, ids_of_oval_variable
+    ):
+        for key, value in element.attrib.items():
+            key = key[key.find("}") + 1:]
+            if key == "var_ref":
+                ref_value = self._get_oval_var_referenced_value(value, ids_of_oval_variable)
+                if ref_value == value:
+                    element_dict[f"{key}@{id_in_items_of_test_property}"] = ref_value
+                else:
+                    element_dict[f"value@{id_in_items_of_test_property}"] = ref_value
+            else:
+                element_dict[f"{key}@{id_in_items_of_test_property}"] = value
+
+    def _get_items(self, xml_test_property):
+        items_of_test_property = {}
+        ids_of_oval_variable = []
+        for element in xml_test_property.iterchildren():
+            id_in_items_of_test_property = (
+                SharedStaticMethodsOfParser.get_unique_id_in_dict(
+                    element, items_of_test_property
+                )
+            )
+
+            element_dict = {}
+            if element.text and element.text.strip():
+                element_dict[f"{id_in_items_of_test_property}@text"] = element.text
+            if "var_ref" in id_in_items_of_test_property:
+                element_dict[
+                    f"value@{id_in_items_of_test_property}"
+                ] = self._get_oval_var_referenced_value(
+                    element.text, ids_of_oval_variable
+                )
+            if element.attrib:
+                self._parse_attributes(
+                    id_in_items_of_test_property,
+                    element,
+                    element_dict,
+                    ids_of_oval_variable,
+                )
+
+            items_of_test_property[id_in_items_of_test_property] = element_dict
+        # TODO: Insert OVAL Variables
+        return items_of_test_property

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -16,42 +16,52 @@ class OVALObjectParser:
         self.collected_objects = collected_objects
         self.system_data = system_data
 
+    def _get_ref_var(self, var_id):
+        # TODO: resolve reference to variable
+        return var_id
+
+    def _get_attributes(self, id_in_items_of_object, element, element_dict):
+        for key, value in element.attrib.items():
+            if key == "var_ref":
+                element_dict[f"{key}@{id_in_items_of_object}"] = self._get_ref_var(value)
+            else:
+                element_dict[f"{key}@{id_in_items_of_object}"] = value
+
     def _get_object_items(self, xml_object):
         items_of_object = {}
         for element in xml_object:
             id_in_items_of_object = SharedStaticMethodsOfParser.get_unique_id_in_dict(
                 element, items_of_object
             )
+            element_dict = {}
             if element.text and element.text.strip():
-                items_of_object[id_in_items_of_object] = element.text
-            else:
-                items_of_object[id_in_items_of_object] = self._get_ref_var(element)
+                element_dict[f"{id_in_items_of_object}@text"] = element.text
+            if element.attrib:
+                self._get_attributes(id_in_items_of_object, element, element_dict)
+            items_of_object[id_in_items_of_object] = element_dict
         return items_of_object
 
-    def _get_item(self, item_ref):
-        item_el = self.system_data.get(item_ref)
-        item = {}
-        for element in item_el:
-            if element.text and element.text.strip():
-                key = SharedStaticMethodsOfParser.get_unique_id_in_dict(element, item)
-                item[key] = element.text
-        return item
-
-    def _get_oval_message(self, id_object):
-        xml_collected_object = self.collected_objects.get(id_object, E.xml("empty"))
+    def _get_oval_message(self, xml_collected_object):
         message = xml_collected_object.find(".//oval-characteristics:message", NAMESPACES)
         if message is not None:
             return OvalObjectMessage(message.get("level", ""), message.text)
         return None
 
+    def _get_collected_object_xml(self, id_object):
+        return self.collected_objects.get(id_object, E.xml("empty"))
+
     def get_object(self, id_object):
         xml_object = self.objects.get(id_object)
         object_dict = {
             "object_id": xml_object.get('id'),
+            "comment": xml_object.get('comment'),
             "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
             "object_data": [self._get_object_items(xml_object)],
         }
-        message = self._get_oval_message(id_object)
+        xml_collected_object = self._get_collected_object_xml(id_object)
+
+        message = self._get_oval_message(xml_collected_object)
         if message is not None:
             object_dict["message"] = message
+        object_dict["flag"] = xml_collected_object.get('flag', '')
         return OvalObject(**object_dict)

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -56,7 +56,7 @@ class OVALObjectParser:
             "object_id": xml_object.get('id'),
             "comment": xml_object.get('comment'),
             "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
-            "object_data": [self._get_object_items(xml_object)],
+            "object_data": self._get_object_items(xml_object),
         }
         xml_collected_object = self._get_collected_object_xml(id_object)
 

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -22,6 +22,7 @@ class OVALObjectParser:
 
     def _get_attributes(self, id_in_items_of_object, element, element_dict):
         for key, value in element.attrib.items():
+            key = key[key.find('}') + 1:]
             if key == "var_ref":
                 element_dict[f"{key}@{id_in_items_of_object}"] = self._get_ref_var(value)
             else:

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -1,6 +1,8 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from lxml.builder import E
+
 from ..data_structures import OvalObject, OvalObjectMessage
 from ..namespaces import NAMESPACES
 from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
@@ -14,30 +16,7 @@ class OVALObjectParser:
         self.collected_objects = collected_objects
         self.system_data = system_data
 
-    @staticmethod
-    def _find_item_ref(object_):
-        list_of_item_ref = [item.get('item_ref') for item in object_]
-        return list(filter(None, list_of_item_ref))
-
-    @staticmethod
-    def _complete_message(item, var_id):
-        if len(item.text) == MAX_MESSAGE_LEN and var_id[:item.text.find('(')] in var_id:
-            return f"{item.text[:item.text.find('(') + 1]}{var_id})"
-        return item.text
-
-    def _get_ref_var(self, element, xml_collected_object):
-        if xml_collected_object is None or 'var_ref' not in element.attrib:
-            return 'no value'
-        variable_values = []
-        var_id = element.get('var_ref')
-        for item in xml_collected_object:
-            if var_id == item.get('variable_id'):
-                variable_values.append(item.text)
-            elif 'message' in SharedStaticMethodsOfParser.get_key_of_xml_element(item):
-                variable_values.append(self._complete_message(item, var_id))
-        return "\n".join(variable_values)
-
-    def _get_object_items(self, xml_object, xml_collected_object):
+    def _get_object_items(self, xml_object):
         items_of_object = {}
         for element in xml_object:
             id_in_items_of_object = SharedStaticMethodsOfParser.get_unique_id_in_dict(
@@ -46,9 +25,7 @@ class OVALObjectParser:
             if element.text and element.text.strip():
                 items_of_object[id_in_items_of_object] = element.text
             else:
-                items_of_object[id_in_items_of_object] = self._get_ref_var(
-                    element, xml_collected_object
-                )
+                items_of_object[id_in_items_of_object] = self._get_ref_var(element)
         return items_of_object
 
     def _get_item(self, item_ref):
@@ -60,44 +37,21 @@ class OVALObjectParser:
                 item[key] = element.text
         return item
 
-    def _get_oval_message(self, xml_collected_object):
+    def _get_oval_message(self, id_object):
+        xml_collected_object = self.collected_objects.get(id_object, E.xml("empty"))
         message = xml_collected_object.find(".//oval-characteristics:message", NAMESPACES)
         if message is not None:
             return OvalObjectMessage(message.get("level", ""), message.text)
         return None
 
-    def _get_collected_objects_info(self, xml_collected_object, xml_object):
-        object_dict = {
-            "object_id": xml_collected_object.get('id'),
-            "flag": xml_collected_object.get('flag'),
-            "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
-        }
-        message = self._get_oval_message(xml_collected_object)
-        if message is not None:
-            object_dict["message"] = message
-
-        if len(xml_collected_object) == 0:
-            object_dict["object_data"] = [self._get_object_items(xml_object, xml_collected_object)]
-        else:
-            item_refs = self._find_item_ref(xml_collected_object)
-            items = []
-            if item_refs:
-                for item_id in item_refs:
-                    items.append(self._get_item(item_id))
-            else:
-                items.append(self._get_object_items(xml_object, xml_collected_object))
-            object_dict["object_data"] = items
-        return OvalObject(**object_dict)
-
     def get_object(self, id_object):
         xml_object = self.objects.get(id_object)
-        xml_collected_object = self.collected_objects.get(id_object)
-        if xml_collected_object is not None:
-            return self._get_collected_objects_info(xml_collected_object, xml_object)
         object_dict = {
             "object_id": xml_object.get('id'),
-            "flag": "does not exist",
             "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
-            "object_data": [self._get_object_items(xml_object, xml_collected_object)],
+            "object_data": [self._get_object_items(xml_object)],
         }
+        message = self._get_oval_message(id_object)
+        if message is not None:
+            object_dict["message"] = message
         return OvalObject(**object_dict)

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -5,45 +5,28 @@ from lxml.builder import E
 
 from ..data_structures import OvalObject, OvalObjectMessage
 from ..namespaces import NAMESPACES
+from .oval_endpoint_information_parser import OVALEndpointInformation
 from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
-MAX_MESSAGE_LEN = 99
 
-
-class OVALObjectParser:
-    def __init__(self, objects, collected_objects, system_data):
+class OVALObjectParser(OVALEndpointInformation):
+    def __init__(
+        self,
+        objects,
+        collected_objects,
+        system_data,
+        oval_var_id_to_value_id,
+        ref_values,
+    ):  # pylint: disable=R0913
+        super().__init__(oval_var_id_to_value_id, ref_values)
         self.objects = objects
         self.collected_objects = collected_objects
         self.system_data = system_data
 
-    def _get_ref_var(self, var_id):
-        # TODO: resolve reference to variable
-        return var_id
-
-    def _get_attributes(self, id_in_items_of_object, element, element_dict):
-        for key, value in element.attrib.items():
-            key = key[key.find('}') + 1:]
-            if key == "var_ref":
-                element_dict[f"{key}@{id_in_items_of_object}"] = self._get_ref_var(value)
-            else:
-                element_dict[f"{key}@{id_in_items_of_object}"] = value
-
-    def _get_object_items(self, xml_object):
-        items_of_object = {}
-        for element in xml_object:
-            id_in_items_of_object = SharedStaticMethodsOfParser.get_unique_id_in_dict(
-                element, items_of_object
-            )
-            element_dict = {}
-            if element.text and element.text.strip():
-                element_dict[f"{id_in_items_of_object}@text"] = element.text
-            if element.attrib:
-                self._get_attributes(id_in_items_of_object, element, element_dict)
-            items_of_object[id_in_items_of_object] = element_dict
-        return items_of_object
-
     def _get_oval_message(self, xml_collected_object):
-        message = xml_collected_object.find(".//oval-characteristics:message", NAMESPACES)
+        message = xml_collected_object.find(
+            ".//oval-characteristics:message", NAMESPACES
+        )
         if message is not None:
             return OvalObjectMessage(message.get("level", ""), message.text)
         return None
@@ -54,15 +37,15 @@ class OVALObjectParser:
     def get_object(self, id_object):
         xml_object = self.objects.get(id_object)
         object_dict = {
-            "object_id": xml_object.get('id'),
-            "comment": xml_object.get('comment'),
+            "object_id": xml_object.get("id"),
+            "comment": xml_object.get("comment", ""),
             "object_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_object),
-            "object_data": self._get_object_items(xml_object),
+            "object_data": self._get_items(xml_object),
         }
         xml_collected_object = self._get_collected_object_xml(id_object)
 
         message = self._get_oval_message(xml_collected_object)
         if message is not None:
             object_dict["message"] = message
-        object_dict["flag"] = xml_collected_object.get('flag', '')
+        object_dict["flag"] = xml_collected_object.get("flag", "")
         return OvalObject(**object_dict)

--- a/openscap_report/scap_results_parser/parsers/oval_result_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_result_parser.py
@@ -25,8 +25,10 @@ class OVALReport:
 
 
 class OVALResultParser:
-    def __init__(self, root):
+    def __init__(self, root, oval_var_id_to_value_id, ref_values):
         self.root = root
+        self.oval_var_id_to_value_id = oval_var_id_to_value_id
+        self.ref_values = ref_values
         self.oval_reports = self._get_oval_reports()
         logging.info(self.oval_reports)
 
@@ -40,7 +42,9 @@ class OVALResultParser:
             report_id = report_element.get("id")
             if "oval" in report_id:
                 oval_results = self._get_oval_results(report_element)
-                parser_info_of_test = OVALTestInfoParser(report_element)
+                parser_info_of_test = OVALTestInfoParser(
+                    report_element, self.oval_var_id_to_value_id, self.ref_values
+                )
                 oval_reports[report_id] = OVALReport(
                     report_id,
                     report_element,

--- a/openscap_report/scap_results_parser/parsers/oval_result_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_result_parser.py
@@ -10,7 +10,7 @@ from lxml.etree import Element
 from ..data_structures import OvalNode
 from ..exceptions import MissingOVALResult
 from ..namespaces import NAMESPACES
-from .oval_test_info_parser import OVALTestInfoParser
+from .oval_test_parser import OVALTestParser
 
 STR_TO_BOOL = {'true': True, 'false': False}
 STR_NEGATION_BOOL = {'true': 'false', 'false': 'true'}
@@ -21,7 +21,7 @@ class OVALReport:
     oval_report_id: str
     oval_report_element: Element
     oval_results_element: Element
-    parser_info_of_oval_test: OVALTestInfoParser
+    oval_test_parser: OVALTestParser
 
 
 class OVALResultParser:
@@ -42,14 +42,14 @@ class OVALResultParser:
             report_id = report_element.get("id")
             if "oval" in report_id:
                 oval_results = self._get_oval_results(report_element)
-                parser_info_of_test = OVALTestInfoParser(
+                oval_test_parser = OVALTestParser(
                     report_element, self.oval_var_id_to_value_id, self.ref_values
                 )
                 oval_reports[report_id] = OVALReport(
                     report_id,
                     report_element,
                     oval_results,
-                    parser_info_of_test
+                    oval_test_parser
                 )
         return oval_reports
 
@@ -108,14 +108,14 @@ class OVALResultParser:
         negation = self._get_negation(child)
         result_of_node = self._get_result(negation, child)
         test_id = child.get('test_ref')
-        parser_of_test_info = self.oval_reports[oval_report_id].parser_info_of_oval_test
+        oval_test_parser = self.oval_reports[oval_report_id].oval_test_parser
         return OvalNode(
             node_id=test_id,
             node_type="value",
             value=result_of_node,
             negation=negation,
             tag="Test",
-            test_info=parser_of_test_info.get_test_info(test_id),
+            test_info=oval_test_parser.get_test_info(test_id),
         )
 
     def _build_node(self, tree, tag, id_definition, oval_report_id):

--- a/openscap_report/scap_results_parser/parsers/oval_state_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_state_parser.py
@@ -25,6 +25,7 @@ class OVALStateParser:
 
     def _get_attributes(self, id_in_items_of_state, element, element_dict):
         for key, value in element.attrib.items():
+            key = key[key.find('}') + 1:]
             if key == "var_ref":
                 element_dict[f"{key}@{id_in_items_of_state}"] = self._get_ref_var(value)
             else:

--- a/openscap_report/scap_results_parser/parsers/oval_state_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_state_parser.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from ..data_structures import OvalState
+from .oval_endpoint_information_parser import OVALEndpointInformation
 from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 
-class OVALStateParser:
-    def __init__(self, states):
+class OVALStateParser(OVALEndpointInformation):
+    def __init__(self, states, oval_var_id_to_value_id, ref_values):
+        super().__init__(oval_var_id_to_value_id, ref_values)
         self.states = states
 
     def get_state(self, state_id):
@@ -15,34 +17,6 @@ class OVALStateParser:
             "state_id": xml_state.attrib.get("id"),
             "comment": xml_state.attrib.get("comment", ""),
             "state_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_state),
-            "state_data": self._get_state_items(xml_state),
+            "state_data": self._get_items(xml_state),
         }
         return OvalState(**state_dict)
-
-    def _get_ref_var(self, var_id):
-        # TODO: resolve reference to variable
-        return var_id
-
-    def _get_attributes(self, id_in_items_of_state, element, element_dict):
-        for key, value in element.attrib.items():
-            key = key[key.find('}') + 1:]
-            if key == "var_ref":
-                element_dict[f"{key}@{id_in_items_of_state}"] = self._get_ref_var(value)
-            else:
-                element_dict[f"{key}@{id_in_items_of_state}"] = value
-
-    def _get_state_items(self, xml_state):
-        items_of_state = {}
-        for element in xml_state.iterchildren():
-            id_in_items_of_state = SharedStaticMethodsOfParser.get_unique_id_in_dict(
-                element, items_of_state
-            )
-
-            element_dict = {}
-            if element.text and element.text.strip():
-                element_dict[f"{id_in_items_of_state}@text"] = element.text
-            if element.attrib:
-                self._get_attributes(id_in_items_of_state, element, element_dict)
-
-            items_of_state[id_in_items_of_state] = element_dict
-        return items_of_state

--- a/openscap_report/scap_results_parser/parsers/oval_state_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_state_parser.py
@@ -19,16 +19,29 @@ class OVALStateParser:
         }
         return OvalState(**state_dict)
 
-    def _get_state_items(self, xml_state):
-        out = {}
-        for element in xml_state.iterchildren():
-            id_in_dict = SharedStaticMethodsOfParser.get_unique_id_in_dict(element, out)
-            if element.text and element.text.strip():
-                out[id_in_dict] = element.text
-            else:
-                out[id_in_dict] = element.get("var_ref")
+    def _get_ref_var(self, var_id):
+        # TODO: resolve reference to variable
+        return var_id
 
-            operation = element.get("operation")
-            if operation is not None:
-                out["operation"] = operation
-        return out
+    def _get_attributes(self, id_in_items_of_state, element, element_dict):
+        for key, value in element.attrib.items():
+            if key == "var_ref":
+                element_dict[f"{key}@{id_in_items_of_state}"] = self._get_ref_var(value)
+            else:
+                element_dict[f"{key}@{id_in_items_of_state}"] = value
+
+    def _get_state_items(self, xml_state):
+        items_of_state = {}
+        for element in xml_state.iterchildren():
+            id_in_items_of_state = SharedStaticMethodsOfParser.get_unique_id_in_dict(
+                element, items_of_state
+            )
+
+            element_dict = {}
+            if element.text and element.text.strip():
+                element_dict[f"{id_in_items_of_state}@text"] = element.text
+            if element.attrib:
+                self._get_attributes(id_in_items_of_state, element, element_dict)
+
+            items_of_state[id_in_items_of_state] = element_dict
+        return items_of_state

--- a/openscap_report/scap_results_parser/parsers/oval_test_info_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_info_parser.py
@@ -72,16 +72,15 @@ class OVALTestInfoParser:  # pylint: disable=R0902
         list_state_of_test = test.xpath('.//*[local-name()="state"]')
 
         oval_object_el = list_object_of_test.pop() if list_object_of_test else None
-        oval_state_el = list_state_of_test.pop() if list_state_of_test else None
 
         oval_object = None
-        oval_state = None
+        oval_states = []
 
         if oval_object_el is not None:
             oval_object = self.objects_parser.get_object(oval_object_el.get("object_ref", ""))
 
-        if oval_state_el is not None:
-            oval_state = self.states_parser.get_state(oval_state_el.get("state_ref", ""))
+        for oval_state_el in list_state_of_test:
+            oval_states.append(self.states_parser.get_state(oval_state_el.get("state_ref", "")))
 
         return OvalTest(
             test_id=test_id,
@@ -90,5 +89,5 @@ class OVALTestInfoParser:  # pylint: disable=R0902
             test_type=test.tag[test.tag.index('}') + 1:],
             comment=test.attrib.get("comment", ""),
             oval_object=oval_object,
-            oval_state=oval_state,
+            oval_states=oval_states,
         )

--- a/openscap_report/scap_results_parser/parsers/oval_test_info_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_info_parser.py
@@ -10,7 +10,7 @@ MAX_MESSAGE_LEN = 99
 
 
 class OVALTestInfoParser:  # pylint: disable=R0902
-    def __init__(self, oval_report):
+    def __init__(self, oval_report, oval_var_id_to_value_id, ref_values):
         self.oval_report = oval_report
         self.oval_definitions = self._get_oval_definitions()
         self.tests = self._get_tests()
@@ -19,11 +19,13 @@ class OVALTestInfoParser:  # pylint: disable=R0902
         self.oval_system_characteristics = self._get_oval_system_characteristics()
         self.collected_objects = self._get_collected_objects_by_id()
         self.system_data = self._get_system_data_by_id()
-        self.states_parser = OVALStateParser(self.states)
+        self.states_parser = OVALStateParser(self.states, oval_var_id_to_value_id, ref_values)
         self.objects_parser = OVALObjectParser(
             self.objects,
             self.collected_objects,
-            self.system_data
+            self.system_data,
+            oval_var_id_to_value_id,
+            ref_values
         )
 
     def _get_oval_system_characteristics(self):

--- a/openscap_report/scap_results_parser/parsers/oval_test_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_parser.py
@@ -9,7 +9,7 @@ from .oval_state_parser import OVALStateParser
 MAX_MESSAGE_LEN = 99
 
 
-class OVALTestInfoParser:  # pylint: disable=R0902
+class OVALTestParser:  # pylint: disable=R0902
     def __init__(self, oval_report, oval_var_id_to_value_id, ref_values):
         self.oval_report = oval_report
         self.oval_definitions = self._get_oval_definitions()

--- a/openscap_report/scap_results_parser/scap_results_parser.py
+++ b/openscap_report/scap_results_parser/scap_results_parser.py
@@ -76,6 +76,15 @@ class SCAPResultsParser():
                 references.append(rule.oval_reference)
         return set(tuple(references))
 
+    @staticmethod
+    def _get_map_oval_var_to_value(test_results_el):
+        return {
+            check_export.attrib.get("export-name"): check_export.attrib.get("value-id", "")
+            for check_export in test_results_el.findall(
+                ".//xccdf:rule-result//xccdf:check//xccdf:check-export", NAMESPACES
+            )
+        }
+
     def parse_report(self):
         test_results_el = self.root.find('.//xccdf:TestResult', NAMESPACES)
         benchmark_el = self._get_benchmark_element()
@@ -93,7 +102,9 @@ class SCAPResultsParser():
         OVAL_and_CPE_tree_builder = OVALAndCPETreeBuilder(  # pylint: disable=C0103
             self.root, group_parser,
             report.profile_info.get_list_of_cpe_platforms_that_satisfy_evaluation_target(),
-            oval_definitions_and_results_sources
+            oval_definitions_and_results_sources,
+            self._get_map_oval_var_to_value(test_results_el),
+            self.ref_values,
         )
         OVAL_and_CPE_tree_builder.insert_oval_and_cpe_trees_to_rules(rules)
 


### PR DESCRIPTION
This PR reworks the presentation of OVAL objects and states in the HTML report. It displays OVAL object and state definitions instead of collected objects. This helps performance, for example, when a large file system is being collected as collected objects.

The new presentation of OVAL Object and OVAL State:
![image](https://github.com/OpenSCAP/openscap-report/assets/26072444/1835cd37-21b8-48b0-b9b9-f7d9f8a39647)

Fixes: #208, #176 

Referenced variables, filters, set elements, etc. are implemented in  PR #211: