### PR TITLE
Resolve references to OVAL endpoints

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -578,22 +578,6 @@ function get_table_body(objects) {
     return tbody;
 }
 
-function get_OVAL_object_info_heading(oval_object) {
-    const div = DIV.cloneNode();
-    const h1 = H1.cloneNode();
-    h1.textContent ='OVAL Object definition: ';
-    h1.className = "pf-c-title pf-m-lg";
-    div.appendChild(BR.cloneNode());
-    div.appendChild(h1);
-
-
-    div.appendChild(get_label("pf-m-blue", `OVAL Object ID: ${oval_object.object_id}\u00A0`, undefined, "", "", oval_object.comment));
-    div.appendChild(get_label("pf-m-blue", `OVAL Object type: ${oval_object.object_type}\u00A0`));
-    div.appendChild(get_label("pf-m-blue", `Flag: ${oval_object.flag}\u00A0`));
-
-    return div;
-}
-
 function generate_property_elements(table_div, endpoint, data) {
     for (const [key, value] of Object.entries(data)) { // eslint-disable-line array-element-newline
         if(Object.values(value).every(v => typeof v === "object")) {
@@ -621,6 +605,21 @@ function generate_property_elements(table_div, endpoint, data) {
             table.appendChild(get_table_body(objects));
         }
     }
+}
+
+function get_OVAL_object_info_heading(oval_object) {
+    const div = DIV.cloneNode();
+    const h1 = H1.cloneNode();
+    h1.textContent ='OVAL Object definition: ';
+    h1.className = "pf-c-title pf-m-lg";
+    div.appendChild(BR.cloneNode());
+    div.appendChild(h1);
+
+    div.appendChild(get_label("pf-m-blue", `OVAL Object ID: ${oval_object.object_id}\u00A0`, undefined, "", "", oval_object.comment));
+    div.appendChild(get_label("pf-m-blue", `OVAL Object type: ${oval_object.object_type}\u00A0`));
+    div.appendChild(get_label("pf-m-blue", `Flag: ${oval_object.flag}\u00A0`));
+
+    return div;
 }
 
 function generate_OVAL_object(oval_object, div) {

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -582,14 +582,14 @@ function generate_property_elements(table_div, endpoint, data) {
     for (const [key, value] of Object.entries(data)) { // eslint-disable-line array-element-newline
         if(Object.values(value).every(v => typeof v === "object")) {
             const h1 = H1.cloneNode();
-            h1.textContent = `Element ${key} contains this elements:`;
+            h1.textContent = `Element ${remove_uuid(key)} contains this elements:`;
             h1.className = "pf-c-title pf-m-md";
             table_div.appendChild(h1);
 
             generate_property_elements(table_div, endpoint, value);
         } else {
             const h1 = H1.cloneNode();
-            h1.textContent = `Element ${key}:`;
+            h1.textContent = `Element ${remove_uuid(key)}:`;
             h1.className = "pf-c-title pf-m-md";
             table_div.appendChild(h1);
 

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -665,6 +665,30 @@ function generate_OVAL_state(oval_state, div) {
     generate_property_elements(table_div, oval_state, oval_state.state_data);
 }
 
+function get_OVAL_variable_info_heading(oval_variable) {
+    const div = DIV.cloneNode();
+    const h1 = H1.cloneNode();
+    h1.textContent ='OVAL Variable definition: ';
+    h1.className = "pf-c-title pf-m-lg";
+    div.appendChild(BR.cloneNode());
+    div.appendChild(h1);
+
+    div.appendChild(get_label("pf-m-blue", `OVAL Variable ID: ${oval_variable.variable_id}\u00A0`, undefined, "", "", oval_variable.comment));
+    div.appendChild(get_label("pf-m-blue", `OVAL Variable type: ${oval_variable.variable_type}\u00A0`));
+    return div;
+}
+
+function generate_OVAL_variable(oval_variable, div) {
+    if (oval_variable === null) {
+        return;
+    }
+    div.appendChild(get_OVAL_variable_info_heading(oval_variable));
+    const table_div = DIV.cloneNode();
+    table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
+    div.appendChild(table_div);
+
+    generate_property_elements(table_div, oval_variable, oval_variable.variable_data);
+}
 
 function generate_OVAL_error_message(test_info, div) {
     div.appendChild(BR.cloneNode());
@@ -696,6 +720,26 @@ function generate_OVAL_error_message(test_info, div) {
     div.appendChild(BR.cloneNode());
 }
 
+function generate_referenced_endpoints(test_info, div) {
+    if (Object.keys(test_info.referenced_oval_endpoints).length > 0) {
+        const h1 = H1.cloneNode();
+        h1.textContent ='Referenced endpoints: ';
+        h1.className = "pf-c-title pf-m-lg";
+        div.appendChild(BR.cloneNode());
+        div.appendChild(h1);
+        for (const [id, endpoint] of Object.entries(test_info.referenced_oval_endpoints)) { // eslint-disable-line array-element-newline
+            if(id.includes(":var:")) {
+                generate_OVAL_variable(endpoint, div);
+            } else if(id.includes(":obj:")) {
+                generate_OVAL_object(endpoint, div);
+            } else {
+                // eslint-disable-next-line no-console
+                console.error("Not implemented endpoint type!");
+            }
+        }
+    }
+}
+
 function get_OVAL_test_info(test_info) {
     const div = DIV.cloneNode();
     div.className = "pf-c-accordion__expanded-content-body";
@@ -720,6 +764,7 @@ function get_OVAL_test_info(test_info) {
     for (const oval_state of test_info.oval_states) {
         generate_OVAL_state(oval_state, div);
     }
+    generate_referenced_endpoints(test_info, div);
     return div;
 }
 

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -732,6 +732,13 @@ function generate_referenced_endpoints(test_info, div) {
                 generate_OVAL_variable(endpoint, div);
             } else if(id.includes(":obj:")) {
                 generate_OVAL_object(endpoint, div);
+            } else if(id.includes(":ste:")) {
+                div.appendChild(BR.cloneNode());
+                const heading = H1.cloneNode();
+                heading.textContent ='OVAL State definition: ';
+                heading.className = "pf-c-title pf-m-lg";
+                div.appendChild(heading);
+                generate_OVAL_state(endpoint, div);
             } else {
                 // eslint-disable-next-line no-console
                 console.error("Not implemented endpoint type!");

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -594,33 +594,47 @@ function get_OVAL_object_info_heading(oval_object) {
     return div;
 }
 
-function generate_OVAL_object(test_info, div) {
-    if (test_info.oval_object === undefined) {
+function generate_property_elements(table_div, endpoint, data) {
+    for (const [key, value] of Object.entries(data)) { // eslint-disable-line array-element-newline
+        if(Object.values(value).every(v => typeof v === "object")) {
+            const h1 = H1.cloneNode();
+            h1.textContent = `Element ${key} contains this elements:`;
+            h1.className = "pf-c-title pf-m-md";
+            table_div.appendChild(h1);
+
+            generate_property_elements(table_div, endpoint, value);
+        } else {
+            const h1 = H1.cloneNode();
+            h1.textContent = `Element ${key}:`;
+            h1.className = "pf-c-title pf-m-md";
+            table_div.appendChild(h1);
+
+            const table = TABLE.cloneNode();
+            table.className = "pf-c-table pf-m-compact pf-m-grid-md";
+            table.setAttribute("role", "grid");
+            table_div.appendChild(table);
+
+            const objects = [];
+            objects.push(filter_object(value, endpoint));
+
+            table.appendChild(get_table_header(objects));
+            table.appendChild(get_table_body(objects));
+        }
+    }
+}
+
+function generate_OVAL_object(oval_object, div) {
+    if (oval_object === undefined) {
         // eslint-disable-next-line no-console
         console.error("Error: The test information has no OVAL Objects.");
         return;
     }
-    div.appendChild(get_OVAL_object_info_heading(test_info.oval_object));
+    div.appendChild(get_OVAL_object_info_heading(oval_object));
     const table_div = DIV.cloneNode();
     table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
     div.appendChild(table_div);
 
-    for (const [key, value] of Object.entries(test_info.oval_object.object_data)) { // eslint-disable-line array-element-newline
-        const h1 = H1.cloneNode();
-        h1.textContent = `Element ${key}:`;
-        h1.className = "pf-c-title pf-m-md";
-        table_div.appendChild(h1);
-
-        const table = TABLE.cloneNode();
-        table.className = "pf-c-table pf-m-compact pf-m-grid-md";
-        table.setAttribute("role", "grid");
-        table_div.appendChild(table);
-
-        const objects = [];
-        objects.push(filter_object(value, test_info.oval_object));
-        table.appendChild(get_table_header(objects));
-        table.appendChild(get_table_body(objects));
-    }
+    generate_property_elements(table_div, oval_object, oval_object.object_data);
 }
 
 function get_OVAL_state_heading() {
@@ -649,23 +663,7 @@ function generate_OVAL_state(oval_state, div) {
     table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
     div.appendChild(table_div);
 
-    for (const [key, value] of Object.entries(oval_state.state_data)) { // eslint-disable-line array-element-newline
-        const h1 = H1.cloneNode();
-        h1.textContent = `Element ${key}:`;
-        h1.className = "pf-c-title pf-m-md";
-        table_div.appendChild(h1);
-
-        const table = TABLE.cloneNode();
-        table.className = "pf-c-table pf-m-compact pf-m-grid-md";
-        table.setAttribute("role", "grid");
-        table_div.appendChild(table);
-
-        const objects = [];
-        objects.push(filter_object(value, oval_state));
-        table.appendChild(get_table_header(objects));
-        table.appendChild(get_table_body(objects));
-    }
-    div.appendChild(BR.cloneNode());
+    generate_property_elements(table_div, oval_state, oval_state.state_data);
 }
 
 
@@ -714,7 +712,7 @@ function get_OVAL_test_info(test_info) {
         generate_OVAL_error_message(test_info, div);
     }
 
-    generate_OVAL_object(test_info, div);
+    generate_OVAL_object(test_info.oval_object, div);
 
     if (test_info.oval_states.length > 0) {
         div.appendChild(get_OVAL_state_heading());

--- a/openscap_report/scap_results_parser/data_structures/__init__.py
+++ b/openscap_report/scap_results_parser/data_structures/__init__.py
@@ -13,6 +13,7 @@ from .oval_result_eval import (EMPTY_RESULT, FULL_RESULT_TO_SHORT_RESULT,
                                SHORT_RESULT_TO_FULL_RESULT, OvalResult)
 from .oval_state import OvalState
 from .oval_test import OvalTest
+from .oval_variable import OvalVariable
 from .profile_info import ProfileInfo
 from .reference import Reference
 from .remediation import Remediation

--- a/openscap_report/scap_results_parser/data_structures/oval_test.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_test.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from dataclasses import asdict, dataclass, field
-from typing import List
+from typing import Dict, List, Union
 
 from .oval_object import OvalObject
 from .oval_state import OvalState
+from .oval_variable import OvalVariable
 
 
 @dataclass
-class OvalTest:
+class OvalTest:  # pylint: disable=R0902
     test_id: str
     check_existence: str = ""
     check: str = ""
@@ -17,6 +18,9 @@ class OvalTest:
     comment: str = ""
     oval_object: OvalObject = None
     oval_states: List[OvalState] = field(default_factory=list)
+    referenced_oval_endpoints: Dict[
+        str, Union[OvalObject, OvalState, OvalVariable]
+    ] = field(default_factory=dict)
 
     def as_dict(self):
         return asdict(self)

--- a/openscap_report/scap_results_parser/data_structures/oval_variable.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_variable.py
@@ -1,0 +1,16 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from dataclasses import asdict, dataclass, field
+from typing import Dict
+
+
+@dataclass
+class OvalVariable:
+    variable_id: str
+    comment: str = ""
+    variable_type: str = ""
+    variable_data: Dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self):
+        return asdict(self)

--- a/openscap_report/scap_results_parser/parsers/__init__.py
+++ b/openscap_report/scap_results_parser/parsers/__init__.py
@@ -9,6 +9,7 @@ from .oval_object_parser import OVALObjectParser
 from .oval_result_parser import OVALResultParser
 from .oval_state_parser import OVALStateParser
 from .oval_test_parser import OVALTestParser
+from .oval_variable_parser import OVALVariableParser
 from .profile_info_parser import ProfileInfoParser
 from .remediation_parser import RemediationParser
 from .report_parser import ReportParser

--- a/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
@@ -5,34 +5,16 @@ from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 
 class OVALEndpointInformation:
-    def __init__(self, oval_var_id_to_value_id, ref_values):
-        self.oval_var_id_to_value_id = oval_var_id_to_value_id
-        self.ref_values = ref_values
-
-    def _get_oval_var_referenced_value(self, var_id, ids_of_oval_variable):
-        value_id = self.oval_var_id_to_value_id.get(var_id, "")
-        value = self.ref_values.get(value_id, var_id)
-        if value == var_id:
-            ids_of_oval_variable.append(var_id)
-        return value
 
     def _parse_attributes(
-        self, id_in_items_of_test_property, element, element_dict, ids_of_oval_variable
+        self, id_in_items_of_test_property, element, element_dict
     ):
         for key, value in element.attrib.items():
             key = key[key.find("}") + 1:]
-            if key == "var_ref":
-                ref_value = self._get_oval_var_referenced_value(value, ids_of_oval_variable)
-                if ref_value == value:
-                    element_dict[f"{key}@{id_in_items_of_test_property}"] = ref_value
-                else:
-                    element_dict[f"value@{id_in_items_of_test_property}"] = ref_value
-            else:
-                element_dict[f"{key}@{id_in_items_of_test_property}"] = value
+            element_dict[f"{key}@{id_in_items_of_test_property}"] = value
 
     def _get_items(self, xml_test_property):
         items_of_test_property = {}
-        ids_of_oval_variable = []
         for element in xml_test_property.iterchildren():
             id_in_items_of_test_property = (
                 SharedStaticMethodsOfParser.get_unique_id_in_dict(
@@ -43,20 +25,14 @@ class OVALEndpointInformation:
             element_dict = {}
             if element.text and element.text.strip():
                 element_dict[f"{id_in_items_of_test_property}@text"] = element.text
-            if "var_ref" in id_in_items_of_test_property:
-                element_dict[
-                    f"value@{id_in_items_of_test_property}"
-                ] = self._get_oval_var_referenced_value(
-                    element.text, ids_of_oval_variable
-                )
             if element.attrib:
                 self._parse_attributes(
                     id_in_items_of_test_property,
                     element,
-                    element_dict,
-                    ids_of_oval_variable,
+                    element_dict
                 )
+            if len(element):
+                element_dict = self._get_items(element)
 
             items_of_test_property[id_in_items_of_test_property] = element_dict
-        # TODO: Insert OVAL Variables
         return items_of_test_property

--- a/openscap_report/scap_results_parser/parsers/oval_object_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_object_parser.py
@@ -10,15 +10,7 @@ from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 
 class OVALObjectParser(OVALEndpointInformation):
-    def __init__(
-        self,
-        objects,
-        collected_objects,
-        system_data,
-        oval_var_id_to_value_id,
-        ref_values,
-    ):  # pylint: disable=R0913
-        super().__init__(oval_var_id_to_value_id, ref_values)
+    def __init__(self, objects, collected_objects, system_data):
         self.objects = objects
         self.collected_objects = collected_objects
         self.system_data = system_data

--- a/openscap_report/scap_results_parser/parsers/oval_state_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_state_parser.py
@@ -7,8 +7,7 @@ from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 
 class OVALStateParser(OVALEndpointInformation):
-    def __init__(self, states, oval_var_id_to_value_id, ref_values):
-        super().__init__(oval_var_id_to_value_id, ref_values)
+    def __init__(self, states):
         self.states = states
 
     def get_state(self, state_id):

--- a/openscap_report/scap_results_parser/parsers/oval_test_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_parser.py
@@ -83,7 +83,9 @@ class OVALTestParser:  # pylint: disable=R0902
             if isinstance(value, dict):
                 OVALTestParser._iter_over_data_and_get_references(value, out)
             else:
-                if "object_reference" in key or "var_ref" in key or "object_ref" in key:
+                matches_key = ["object_reference", "var_ref", "object_ref", "filter"]
+                matches_val = [":var:", ":obj:", ":ste:"]
+                if any(s in key for s in matches_key) and any(s in value for s in matches_val):
                     out.append(value)
 
     def _resolve_reference(self, ref_id, new_ref, out):
@@ -95,6 +97,10 @@ class OVALTestParser:  # pylint: disable=R0902
             object_ = self.objects_parser.get_object(ref_id)
             self._iter_over_data_and_get_references(object_.object_data, new_ref)
             out[ref_id] = object_
+        elif ":ste:" in ref_id:
+            state = self.states_parser.get_state(ref_id)
+            self._iter_over_data_and_get_references(state.state_data, new_ref)
+            out[ref_id] = state
         else:
             logging.warning(ref_id)
 

--- a/openscap_report/scap_results_parser/parsers/oval_test_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_parser.py
@@ -1,12 +1,13 @@
 # Copyright 2022, Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import logging
+
 from ..data_structures import OvalTest
 from ..namespaces import NAMESPACES
 from .oval_object_parser import OVALObjectParser
 from .oval_state_parser import OVALStateParser
-
-MAX_MESSAGE_LEN = 99
+from .oval_variable_parser import OVALVariableParser
 
 
 class OVALTestParser:  # pylint: disable=R0902
@@ -16,16 +17,20 @@ class OVALTestParser:  # pylint: disable=R0902
         self.tests = self._get_tests()
         self.objects = self._get_objects_by_id()
         self.states = self._get_states_by_id()
+        self.variables = self._get_variables_by_id()
         self.oval_system_characteristics = self._get_oval_system_characteristics()
         self.collected_objects = self._get_collected_objects_by_id()
         self.system_data = self._get_system_data_by_id()
-        self.states_parser = OVALStateParser(self.states, oval_var_id_to_value_id, ref_values)
+        self.variable_parser = OVALVariableParser(
+            self.variables,
+            oval_var_id_to_value_id,
+            ref_values
+        )
+        self.states_parser = OVALStateParser(self.states)
         self.objects_parser = OVALObjectParser(
             self.objects,
             self.collected_objects,
-            self.system_data,
-            oval_var_id_to_value_id,
-            ref_values
+            self.system_data
         )
 
     def _get_oval_system_characteristics(self):
@@ -67,6 +72,45 @@ class OVALTestParser:  # pylint: disable=R0902
             ('.//oval-definitions:states'), NAMESPACES)
         return self._get_data_by_id(data)
 
+    def _get_variables_by_id(self):
+        data = self.oval_definitions.find(
+            ('.//oval-definitions:variables'), NAMESPACES)
+        return self._get_data_by_id(data)
+
+    @staticmethod
+    def _iter_over_data_and_get_references(dict_, out):
+        for key, value in dict_.items():
+            if isinstance(value, dict):
+                OVALTestParser._iter_over_data_and_get_references(value, out)
+            else:
+                if "object_reference" in key or "var_ref" in key or "object_ref" in key:
+                    out.append(value)
+
+    def _resolve_reference(self, ref_id, new_ref, out):
+        if ":var:" in ref_id:
+            variable = self.variable_parser.get_variable(ref_id)
+            self._iter_over_data_and_get_references(variable.variable_data, new_ref)
+            out[ref_id] = variable
+        elif ":obj:" in ref_id:
+            object_ = self.objects_parser.get_object(ref_id)
+            self._iter_over_data_and_get_references(object_.object_data, new_ref)
+            out[ref_id] = object_
+        else:
+            logging.warning(ref_id)
+
+    def _get_referenced_endpoints(self, oval_object, oval_states):
+        references = []
+        object_data = oval_object.object_data if oval_object is not None else {}
+        self._iter_over_data_and_get_references(object_data, references)
+        for state in oval_states:
+            self._iter_over_data_and_get_references(state.state_data, references)
+
+        out = {}
+        while len(references) != 0:
+            ref = references.pop()
+            self._resolve_reference(ref, references, out)
+        return out
+
     def get_test_info(self, test_id):
         test = self.tests[test_id]
 
@@ -84,6 +128,8 @@ class OVALTestParser:  # pylint: disable=R0902
         for oval_state_el in list_state_of_test:
             oval_states.append(self.states_parser.get_state(oval_state_el.get("state_ref", "")))
 
+        referenced_oval_endpoints = self._get_referenced_endpoints(oval_object, oval_states)
+
         return OvalTest(
             test_id=test_id,
             check_existence=test.attrib.get("check_existence", ""),
@@ -92,4 +138,5 @@ class OVALTestParser:  # pylint: disable=R0902
             comment=test.attrib.get("comment", ""),
             oval_object=oval_object,
             oval_states=oval_states,
+            referenced_oval_endpoints=referenced_oval_endpoints,
         )

--- a/openscap_report/scap_results_parser/parsers/oval_variable_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_variable_parser.py
@@ -1,0 +1,33 @@
+# Copyright 2022, Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from ..data_structures import OvalVariable
+from .oval_endpoint_information_parser import OVALEndpointInformation
+from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
+
+
+class OVALVariableParser(OVALEndpointInformation):
+    def __init__(self, variables, oval_var_id_to_value_id, ref_values):
+        self.oval_var_id_to_value_id = oval_var_id_to_value_id
+        self.ref_values = ref_values
+        self.variables = variables
+
+    def get_variable(self, variable_id):
+        xml_variable = self.variables[variable_id]
+        variable_dict = {
+            "variable_id": xml_variable.attrib.get("id"),
+            "comment": xml_variable.attrib.get("comment", ""),
+            "variable_type": SharedStaticMethodsOfParser.get_key_of_xml_element(xml_variable),
+            "variable_data": self._get_items(xml_variable),
+        }
+
+        if variable_dict["variable_type"] == "external_variable":
+            variable_dict["variable_data"] = {
+                "external_variable": {
+                    "value": self.ref_values.get(
+                        self.oval_var_id_to_value_id.get(variable_id, ""),
+                        "not found"
+                    )
+                }
+            }
+        return OvalVariable(**variable_dict)


### PR DESCRIPTION
This PR deals with references to OVAL Variables and Objects, and displays embed elements such as set, concat etc... 

See the example of the new detail of the OVAL Test:
![image](https://github.com/OpenSCAP/openscap-report/assets/26072444/e1a5f878-3e94-4018-a7c2-234b7e650cdc)
