### PR TITLE
Fix of `pre` element width

### DIFF
--- a/openscap_report/report_generators/html_templates/css/style.css
+++ b/openscap_report/report_generators/html_templates/css/style.css
@@ -21,6 +21,7 @@ pre {
     white-space: -o-pre-wrap;
     word-wrap: break-word;
     margin: 5px;
+    width: fit-content;
 }
 
 details pre {


### PR DESCRIPTION
This PR fixes the width of the `pre` element. The gray background of `pre` elements is not expanded.  
![image](https://github.com/OpenSCAP/openscap-report/assets/26072444/9236b469-83fd-4f58-a1cb-0e23249bc547)


New lines cannot be fixed because this would change the meaning of the `pre` element. For inline code, I would suggest using the `code` element. This change is at the Content level. 