### PR TITLE
Reorganization of OVAL Test results 

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -28,6 +28,14 @@ function show_OVAL_details(event) { // eslint-disable-line no-unused-vars
     event.currentTarget.param_this.setAttribute('aria-label', event.currentTarget.param_this.textContent);
 }
 
+function show_OVAL_referenced_endpoints(event) { // eslint-disable-line no-unused-vars
+    event.currentTarget.param_this.classList.toggle('pf-m-expanded');
+    event.currentTarget.param_this.setAttribute('aria-expanded', event.currentTarget.param_this.aria_expanded === "false"? "true": "false");
+    event.currentTarget.param_content.classList.toggle('pf-m-expanded');
+    hide_or_show(event.currentTarget.param_content); // eslint-disable-line no-undef
+
+}
+
 // OVAL graph generation constants
 
 

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -98,9 +98,11 @@ const COL = document.createElement("td");
 const HEADER_COL = document.createElement("th");
 
 const H1 = document.createElement("h1");
+const H3 = document.createElement("h3");
 
 const BR = document.createElement("br");
 const B = document.createElement("b");
+const HR = document.createElement("hr");
 
 const SMALL = document.createElement("small");
 const I = document.createElement("i");
@@ -747,6 +749,15 @@ function generate_referenced_endpoints(test_info, div) {
             }
         }
     }
+}
+
+function get_spacer() {
+    const hr = HR.cloneNode();
+    const spacer = DIV.cloneNode();
+    spacer.appendChild(BR.cloneNode());
+    spacer.appendChild(hr);
+    spacer.appendChild(BR.cloneNode());
+    return spacer;
 }
 
 function get_OVAL_test_info(test_info) {

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -781,23 +781,30 @@ function add_header_referenced_endpoints_and_get_body(div) {
     return body;
 }
 
-function generate_referenced_endpoints(test_info, children_id, div) {
-    if (test_info.map_referenced_oval_endpoints[children_id].length > 0) {
-        const body = add_header_referenced_endpoints_and_get_body(div);
+function generate_endpoint(id, test_info, body) {
+    const endpoint = test_info.referenced_oval_endpoints[id];
 
-        for (const id of test_info.map_referenced_oval_endpoints[children_id]) {
-            const endpoint = test_info.referenced_oval_endpoints[id];
-            if(id.includes(":var:")) {
-                generate_OVAL_variable(test_info, endpoint, body);
-            } else if(id.includes(":obj:")) {
-                generate_OVAL_object(test_info, endpoint, body);
-            } else if(id.includes(":ste:")) {
-                generate_OVAL_state(test_info, endpoint, body, true);
-            } else {
-                // eslint-disable-next-line no-console
-                console.error("Not implemented endpoint type!");
-            }
-        }
+    if(id.includes(":var:")) {
+        generate_OVAL_variable(test_info, endpoint, body);
+    } else if(id.includes(":obj:")) {
+        generate_OVAL_object(test_info, endpoint, body);
+    } else if(id.includes(":ste:")) {
+        generate_OVAL_state(test_info, endpoint, body, true);
+    } else {
+        // eslint-disable-next-line no-console
+        console.error("Not implemented endpoint type!");
+    }
+}
+
+function generate_referenced_endpoints(test_info, children_id, div) {
+    if (test_info.map_referenced_oval_endpoints[children_id].length == 0) {
+        return;
+    }
+
+    const body = add_header_referenced_endpoints_and_get_body(div);
+
+    for (const id of test_info.map_referenced_oval_endpoints[children_id]) {
+        generate_endpoint(id, test_info, body);
     }
 }
 

--- a/openscap_report/scap_results_parser/data_structures/oval_test.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_test.py
@@ -21,6 +21,7 @@ class OvalTest:  # pylint: disable=R0902
     referenced_oval_endpoints: Dict[
         str, Union[OvalObject, OvalState, OvalVariable]
     ] = field(default_factory=dict)
+    map_referenced_oval_endpoints: Dict[str, list] = field(default_factory=dict)
 
     def as_dict(self):
         return asdict(self)

--- a/openscap_report/scap_results_parser/parsers/oval_test_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_parser.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import logging
+from collections import defaultdict
 
 from ..data_structures import OvalTest
 from ..namespaces import NAMESPACES
@@ -89,8 +90,6 @@ class OVALTestParser:  # pylint: disable=R0902
                 matches_val = [":var:", ":obj:", ":ste:"]
                 if any(s in key for s in matches_key) and any(s in value for s in matches_val):
                     out.append(value)
-                    if data_id not in map_referenced_oval_endpoints:
-                        map_referenced_oval_endpoints[data_id] = []
                     if value not in map_referenced_oval_endpoints[data_id]:
                         map_referenced_oval_endpoints[data_id].append(value)
 
@@ -150,7 +149,7 @@ class OVALTestParser:  # pylint: disable=R0902
         for oval_state_el in list_state_of_test:
             oval_states.append(self.states_parser.get_state(oval_state_el.get("state_ref", "")))
 
-        map_referenced_oval_endpoints = {}
+        map_referenced_oval_endpoints = defaultdict(list)
 
         referenced_oval_endpoints = self._get_referenced_endpoints(
             oval_object, oval_states, map_referenced_oval_endpoints
@@ -165,5 +164,5 @@ class OVALTestParser:  # pylint: disable=R0902
             oval_object=oval_object,
             oval_states=oval_states,
             referenced_oval_endpoints=referenced_oval_endpoints,
-            map_referenced_oval_endpoints=map_referenced_oval_endpoints,
+            map_referenced_oval_endpoints=dict(map_referenced_oval_endpoints),
         )

--- a/openscap_report/scap_results_parser/parsers/oval_test_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_test_parser.py
@@ -78,43 +78,59 @@ class OVALTestParser:  # pylint: disable=R0902
         return self._get_data_by_id(data)
 
     @staticmethod
-    def _iter_over_data_and_get_references(dict_, out):
+    def _iter_over_data_and_get_references(dict_, out, data_id, map_referenced_oval_endpoints):
         for key, value in dict_.items():
             if isinstance(value, dict):
-                OVALTestParser._iter_over_data_and_get_references(value, out)
+                OVALTestParser._iter_over_data_and_get_references(
+                    value, out, data_id, map_referenced_oval_endpoints
+                )
             else:
                 matches_key = ["object_reference", "var_ref", "object_ref", "filter"]
                 matches_val = [":var:", ":obj:", ":ste:"]
                 if any(s in key for s in matches_key) and any(s in value for s in matches_val):
                     out.append(value)
+                    if data_id not in map_referenced_oval_endpoints:
+                        map_referenced_oval_endpoints[data_id] = []
+                    if value not in map_referenced_oval_endpoints[data_id]:
+                        map_referenced_oval_endpoints[data_id].append(value)
 
-    def _resolve_reference(self, ref_id, new_ref, out):
+    def _resolve_reference(self, ref_id, new_ref, out, map_referenced_oval_endpoints):
         if ":var:" in ref_id:
             variable = self.variable_parser.get_variable(ref_id)
-            self._iter_over_data_and_get_references(variable.variable_data, new_ref)
+            self._iter_over_data_and_get_references(
+                variable.variable_data, new_ref, ref_id, map_referenced_oval_endpoints
+            )
             out[ref_id] = variable
         elif ":obj:" in ref_id:
             object_ = self.objects_parser.get_object(ref_id)
-            self._iter_over_data_and_get_references(object_.object_data, new_ref)
+            self._iter_over_data_and_get_references(
+                object_.object_data, new_ref, ref_id, map_referenced_oval_endpoints
+            )
             out[ref_id] = object_
         elif ":ste:" in ref_id:
             state = self.states_parser.get_state(ref_id)
-            self._iter_over_data_and_get_references(state.state_data, new_ref)
+            self._iter_over_data_and_get_references(
+                state.state_data, new_ref, ref_id, map_referenced_oval_endpoints
+            )
             out[ref_id] = state
         else:
             logging.warning(ref_id)
 
-    def _get_referenced_endpoints(self, oval_object, oval_states):
+    def _get_referenced_endpoints(self, oval_object, oval_states, map_referenced_oval_endpoints):
         references = []
         object_data = oval_object.object_data if oval_object is not None else {}
-        self._iter_over_data_and_get_references(object_data, references)
+        self._iter_over_data_and_get_references(
+            object_data, references, oval_object.object_id, map_referenced_oval_endpoints,
+        )
         for state in oval_states:
-            self._iter_over_data_and_get_references(state.state_data, references)
+            self._iter_over_data_and_get_references(
+                state.state_data, references, state.state_id, map_referenced_oval_endpoints,
+            )
 
         out = {}
         while len(references) != 0:
             ref = references.pop()
-            self._resolve_reference(ref, references, out)
+            self._resolve_reference(ref, references, out, map_referenced_oval_endpoints)
         return out
 
     def get_test_info(self, test_id):
@@ -134,7 +150,11 @@ class OVALTestParser:  # pylint: disable=R0902
         for oval_state_el in list_state_of_test:
             oval_states.append(self.states_parser.get_state(oval_state_el.get("state_ref", "")))
 
-        referenced_oval_endpoints = self._get_referenced_endpoints(oval_object, oval_states)
+        map_referenced_oval_endpoints = {}
+
+        referenced_oval_endpoints = self._get_referenced_endpoints(
+            oval_object, oval_states, map_referenced_oval_endpoints
+        )
 
         return OvalTest(
             test_id=test_id,
@@ -145,4 +165,5 @@ class OVALTestParser:  # pylint: disable=R0902
             oval_object=oval_object,
             oval_states=oval_states,
             referenced_oval_endpoints=referenced_oval_endpoints,
+            map_referenced_oval_endpoints=map_referenced_oval_endpoints,
         )


### PR DESCRIPTION
This PR changes the representation of components referenced by OVAL Tests, such as Objects, States, and Variables. 

See the new representation:
 
![image](https://github.com/OpenSCAP/openscap-report/assets/26072444/33e58f45-a08f-49b5-8caf-c6c6ffc8b7cf)

Fixes: #216 