### PR TITLE
Fix a traceback

### DIFF
--- a/openscap_report/scap_results_parser/parsers/profile_info_parser.py
+++ b/openscap_report/scap_results_parser/parsers/profile_info_parser.py
@@ -7,6 +7,7 @@ from lxml.builder import E
 
 from ..data_structures import ProfileInfo
 from ..namespaces import NAMESPACES
+from .shared_static_methods_of_parser import SharedStaticMethodsOfParser
 
 
 class ProfileInfoParser:
@@ -45,8 +46,8 @@ class ProfileInfoParser:
         description = profile_el.find('.//xccdf:description', NAMESPACES)
         profile_info_dict = {
             "profile_id": profile_id,
-            "title": title.text if title is not None else "",
-            "description": description.text if description is not None else "",
+            "title": SharedStaticMethodsOfParser.get_text_of_xml_element(title),
+            "description": SharedStaticMethodsOfParser.get_text_of_xml_element(description),
             "extends": profile_el.get("extends", ""),
             "cpe_platforms_for_profile": self._get_cpe_platforms_for_profile()
         }

--- a/openscap_report/scap_results_parser/parsers/shared_static_methods_of_parser.py
+++ b/openscap_report/scap_results_parser/parsers/shared_static_methods_of_parser.py
@@ -15,6 +15,12 @@ class SharedStaticMethodsOfParser:
         return element.tag[element.tag.index('}') + 1:] if '}' in element.tag else element.tag
 
     @staticmethod
+    def get_text_of_xml_element(element):
+        if element is not None and element.text is not None:
+            return "".join(element.itertext())
+        return ""
+
+    @staticmethod
     def get_unique_id_in_dict(object_, dict_):
         if SharedStaticMethodsOfParser.get_key_of_xml_element(object_) in dict_:
             return SharedStaticMethodsOfParser.get_unique_key(

--- a/tests/unit_tests/test_shared_static_methods_of_parser.py
+++ b/tests/unit_tests/test_shared_static_methods_of_parser.py
@@ -30,3 +30,21 @@ def test_get_unique_id_in_dict(object_, dict_):
 def test_get_key_of_xml_element(element, expect_key):
     key_element = SharedStaticMethodsOfParser.get_key_of_xml_element(element)
     assert key_element == expect_key
+
+
+@pytest.fixture
+def element(request):
+    e = etree.Element("xml_element")
+    e.text = request.param
+    return e
+
+
+@pytest.mark.unit_test
+@pytest.mark.parametrize("element, expected_text", [
+    (None, ""),
+    ("", ""),
+    ("abcd", "abcd"),
+], indirect=["element"])
+def test_get_text_of_xml_element(element, expected_text):
+    text = SharedStaticMethodsOfParser.get_text_of_xml_element(element)
+    assert text == expected_text


### PR DESCRIPTION
Ensure the `title` and `description` members of ProfileInfo objects are not None.

Fixes: #233