### PR TITLE
Move to UBI8 for C8S testing

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -25,11 +25,11 @@ jobs:
         working-directory: ./tests
         run: ./smoke.sh
 
-  test-centos-stream-8:
-    name: Test on CentOS Stream 8 (Container)
+  test-rhel-8:
+    name: Test on RHEL 8 (Container)
     runs-on: ubuntu-latest
     container:
-      image: quay.io/centos/centos:stream8
+      image: registry.access.redhat.com/ubi8/ubi:latest
     steps:
       - name: Install Deps
         run: dnf install -y python3 python3-devel python3-setuptools rpm-build


### PR DESCRIPTION
Since C8S is no longer supported, use [UBI](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/using_red_hat_universal_base_images_standard_minimal_and_runtimes#pull_ubi_images) instead.