### PR TITLE
Improve layout of test details window

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -362,6 +362,26 @@ function render_OVAL_test(node_data) {
     return test_node;
 }
 
+function add_kv_entry(tbody, key, value) {
+    const row = ROW.cloneNode();
+    row.setAttribute("role", "row");
+    tbody.appendChild(row);
+    const first_col = COL.cloneNode();
+    first_col.setAttribute("role", "cell");
+    first_col.className = "pf-m-truncate pf-m-fit-content";
+    first_col.appendChild(get_bold_text(key + ":"));
+    row.appendChild(first_col);
+    const second_col = COL.cloneNode();
+    second_col.setAttribute("role", "cell");
+    second_col.className = "pf-m-truncate pf-m-fit-content";
+    if (typeof value === "string") {
+        second_col.textContent = value;
+    } else {
+        second_col.appendChild(value);
+    }
+    row.appendChild(second_col);
+}
+
 function get_icon_as_html(icon) {
     const html_icon = SPAN.cloneNode();
     html_icon.className = "pf-c-label__icon";

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -628,7 +628,7 @@ function generate_endpoint_element(tbody, element_id, element_dict) {
             col.textContent = value;
             row.appendChild(col);
         } else {
-            label_key = remove_uuid(key);
+            const label_key = remove_uuid(key);
             first_col.appendChild(get_label("pf-m-blue", `${label_key}: ${value}`));
         }
     }

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -619,14 +619,16 @@ function generate_endpoint_element(tbody, element_id, element_dict) {
     first_col.className = "pf-m-truncate pf-m-fit-content";
     row.appendChild(first_col);
     first_col.appendChild(get_bold_text(remove_uuid(element_id) + ":"));
-
+    const second_col = COL.cloneNode();
+    second_col.setAttribute("role", "cell");
+    second_col.className = "pf-m-truncate pf-m-fit-content";
+    row.appendChild(second_col);
     for (const [key, value] of Object.entries(element_dict)) {
-        if (key.endsWith("@text")) {
-            const col = COL.cloneNode();
-            col.setAttribute("role", "cell");
-            col.className = "pf-m-truncate pf-m-fit-content";
-            col.textContent = value;
-            row.appendChild(col);
+        if (key.endsWith("@text") || key.startsWith("var_ref@") || key.startsWith("object_ref@")) {
+            second_col.textContent = value;
+        } else if (typeof value == "object") {
+            // recursion
+            generate_endpoint_element(second_col, key, value);
         } else {
             const label_key = remove_uuid(key);
             first_col.appendChild(get_label("pf-m-blue", `${label_key}: ${value}`));
@@ -636,20 +638,7 @@ function generate_endpoint_element(tbody, element_id, element_dict) {
 
 function generate_endpoint_elements(tbody, data) {
     for (const [element_id, element_dict] of Object.entries(data)) {
-        if (Object.values(element_dict).every(v => typeof v === "object")) {
-            const row = ROW.cloneNode();
-            row.setAttribute("role", "row");
-            tbody.appendChild(row);
-            const col = COL.cloneNode();
-            col.appendChild(get_bold_text(element_id + ":"));
-            row.appendChild(col);
-            const col2 = COL.cloneNode();
-            row.appendChild(col2);
-            // recursion
-            generate_endpoint_elements(col2, element_dict);
-        } else {
-            generate_endpoint_element(tbody, element_id, element_dict);
-        }
+        generate_endpoint_element(tbody, element_id, element_dict);
     }
 }
 

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -618,7 +618,7 @@ function generate_endpoint_element(tbody, element_id, element_dict) {
     first_col.setAttribute("role", "cell");
     first_col.className = "pf-m-truncate pf-m-fit-content";
     row.appendChild(first_col);
-    first_col.appendChild(get_bold_text(element_id + ":"));
+    first_col.appendChild(get_bold_text(remove_uuid(element_id) + ":"));
 
     for (const [key, value] of Object.entries(element_dict)) {
         if (key.endsWith("@text")) {

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -637,7 +637,16 @@ function generate_endpoint_element(tbody, element_id, element_dict) {
 function generate_endpoint_elements(tbody, data) {
     for (const [element_id, element_dict] of Object.entries(data)) {
         if (Object.values(element_dict).every(v => typeof v === "object")) {
-            generate_endpoint_elements(tbody, element_dict);
+            const row = ROW.cloneNode();
+            row.setAttribute("role", "row");
+            tbody.appendChild(row);
+            const col = COL.cloneNode();
+            col.appendChild(get_bold_text(element_id + ":"));
+            row.appendChild(col);
+            const col2 = COL.cloneNode();
+            row.appendChild(col2);
+            // recursion
+            generate_endpoint_elements(col2, element_dict);
         } else {
             generate_endpoint_element(tbody, element_id, element_dict);
         }

--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -405,6 +405,13 @@ function get_bold_text(text) {
     return b;
 }
 
+function get_header(title) {
+    const h1 = H1.cloneNode();
+    h1.textContent = title;
+    h1.className = "pf-c-title pf-m-2xl";
+    return h1;
+}
+
 function get_tooltip(text) {
     const div = DIV.cloneNode();
     div.className = "tooltip-wrapper";

--- a/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_endpoint_information_parser.py
@@ -32,7 +32,8 @@ class OVALEndpointInformation:
                     element_dict
                 )
             if len(element):
-                element_dict = self._get_items(element)
+                # parse children like set, regex_capture, concat
+                element_dict.update(self._get_items(element))
 
             items_of_test_property[id_in_items_of_test_property] = element_dict
         return items_of_test_property


### PR DESCRIPTION
- make the layout more compact to show all related data at a single
  place
- For OVAL objects, create a table where each child element is
  represented as a table row
- OVAL object child elements tag name is shown as first column in the row
- OVAL object child elements text data shown as second column in the row
- OVAL object child elements attributes are shown as labels
- OVAL states and OVAL variables are presented in a similar way
  as OVAL objects as described above
- make sure the test details window is standalone


Any suggestions are welcome. I would appreciate advice on the classes of the HTML elements. Feel free to come up with layout suggestions. I'm also interested in you experience in more complex OVAL tests. Please try it out and report back.