### PR TITLE
Remove OVAL definition class information

### DIFF
--- a/openscap_report/report_generators/html_templates/oval_definition_detail.html
+++ b/openscap_report/report_generators/html_templates/oval_definition_detail.html
@@ -13,13 +13,6 @@
     </td>
 </tr>
 <tr role="row">
-    <th class="pf-m-fit-content" role="rowheader" scope="row"><b>Class:</b></th>
-    <td role="cell">
-        <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
-        <p class="pf-c-table__text">{{ rule.oval_definition.definition_class }}</p></div></div>
-    </td>
-</tr>
-<tr role="row">
     <th class="pf-m-fit-content" role="rowheader" scope="row"><b>Title:</b></th>
     <td role="cell">
         <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
@@ -31,13 +24,6 @@
     <td role="cell">
         <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
         <p class="pf-c-table__text">{{ rule.oval_definition.description }}</p></div></div>
-    </td>
-</tr>
-<tr role="row">
-    <th class="pf-m-fit-content" role="rowheader" scope="row"><b>Class explained:</b></th>
-    <td role="cell">
-        <div class="pf-l-flex pf-m-column"><div class="pf-l-flex__item">
-        <p class="pf-c-table__text">{{ rule.oval_definition.get_oval_class_description() }}</p></div></div>
     </td>
 </tr>
 <tr role="row">

--- a/openscap_report/scap_results_parser/data_structures/oval_definition.py
+++ b/openscap_report/scap_results_parser/data_structures/oval_definition.py
@@ -15,34 +15,10 @@ OVAL_DEFINITION_JSON_KEYS = [
     "version",
 ]
 
-OVAL_CLASS_DESCRIPTION = {
-    "compliance": (
-        "Compliance class describes OVAL Definitions that check to see if a system's state is "
-        'compliant with a specific policy. An evaluation result of "true", for this class of OVAL '
-        "Definitions, indicates that a system is compliant with the stated policy."
-    ),
-    "vulnerability": (
-        "Vulnerability class describes OVAL Definitions that check to see if the system is in a "
-        'vulnerable state. An evaluation result of "true", for this class of OVAL Definitions, '
-        "indicates that the system is in a vulnerable state."
-    ),
-    "inventory": (
-        "Inventory class describes OVAL Definitions that check to see if a piece of software is "
-        'installed on a system. An evaluation result of "true", for this class of OVAL '
-        "Definitions, indicates that the specified software is installed on the system."
-    ),
-    "patch": (
-        "Patch class describes OVAL Definitions that check to see if a patch should be installed "
-        'on a system. An evaluation result of "true", for this class of OVAL Definitions, '
-        "indicates that the specified patch should be installed on the system."
-    ),
-}
-
 
 @dataclass
 class OvalDefinition:
     definition_id: str
-    definition_class: str
     title: str
     description: str = ""
     version: str = ""
@@ -51,6 +27,3 @@ class OvalDefinition:
 
     def as_dict(self):
         return asdict(self)
-
-    def get_oval_class_description(self):
-        return OVAL_CLASS_DESCRIPTION[self.definition_class]

--- a/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
+++ b/openscap_report/scap_results_parser/parsers/oval_definition_parser.py
@@ -29,10 +29,9 @@ class OVALDefinitionParser:
             references.append(OvalReference(ref.get("source"), ref.get("ref_id")))
         return references
 
-    def parse_oval_definition(self, definition_id, definition_class, definition):
+    def parse_oval_definition(self, definition_id, definition):
         oval_definition_dict = {
             "definition_id": definition_id,
-            "definition_class": definition_class,
             "title": definition.find('.//oval-definitions:title', NAMESPACES).text,
             "description": definition.find('.//oval-definitions:description', NAMESPACES).text,
             "version": definition.get("version"),
@@ -48,10 +47,8 @@ class OVALDefinitionParser:
         dict_of_criteria = {}
         for definition in self.oval_definitions[oval]:
             definition_id = definition.get("id")
-            definition_class = definition.get("class")
             oval_definition = self.parse_oval_definition(
                 definition_id,
-                definition_class,
                 definition
             )
             criteria = definition.find('.//oval-definitions:criteria', NAMESPACES)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,7 +98,6 @@ def get_dummy_cpe_oval_definition():
     dummy_oval_definition = OvalDefinition(
         definition_id="dummy_oval_def",
         title="dummy OVAL definition",
-        definition_class="compliance",
         oval_tree=OVAL_TREE_TRUE,
     )
     return {


### PR DESCRIPTION
In normal SCAP content, the OVAL definitions have always class attribute set to compliance. It isn't necessary to show this information in every rule in HTML report and add a long description, it only creates noise.