### PR TITLE
Hide some remediation types

### DIFF
--- a/openscap_report/scap_results_parser/data_structures/remediation.py
+++ b/openscap_report/scap_results_parser/data_structures/remediation.py
@@ -17,6 +17,7 @@ HIDDEN_REMEDIATION_TYPES = [
     "urn:xccdf:fix:script:kickstart",
 ]
 
+
 @dataclass
 class Remediation:
     remediation_id: str

--- a/openscap_report/scap_results_parser/data_structures/remediation.py
+++ b/openscap_report/scap_results_parser/data_structures/remediation.py
@@ -12,6 +12,10 @@ REMEDIATION_JSON_KEYS = [
     "fix",
 ]
 
+HIDDEN_REMEDIATION_TYPES = [
+    "urn:redhat:anaconda:pre",
+    "urn:xccdf:fix:script:kickstart",
+]
 
 @dataclass
 class Remediation:
@@ -33,5 +37,6 @@ class Remediation:
             "urn:redhat:anaconda:pre": "Anaconda snippet",
             "urn:xccdf:fix:script:kubernetes": "Kubernetes snippet",
             "urn:redhat:osbuild:blueprint": "OSBuild Blueprint snippet",
+            "urn:xccdf:fix:script:kickstart": "Kickstart snippet",
         }
         return script_types.get(self.system, "script")

--- a/openscap_report/scap_results_parser/parsers/rule_parser.py
+++ b/openscap_report/scap_results_parser/parsers/rule_parser.py
@@ -4,9 +4,9 @@
 import collections
 
 from openscap_report.dataclasses import replace
-from ..data_structures.remediation import HIDDEN_REMEDIATION_TYPES
 
 from ..data_structures import Identifier, Reference, Rule, RuleWarning
+from ..data_structures.remediation import HIDDEN_REMEDIATION_TYPES
 from ..namespaces import NAMESPACES
 from .full_text_parser import FullTextParser
 from .known_references import KNOWN_REFERENCES, update_references

--- a/openscap_report/scap_results_parser/parsers/rule_parser.py
+++ b/openscap_report/scap_results_parser/parsers/rule_parser.py
@@ -4,6 +4,7 @@
 import collections
 
 from openscap_report.dataclasses import replace
+from ..data_structures.remediation import HIDDEN_REMEDIATION_TYPES
 
 from ..data_structures import Identifier, Reference, Rule, RuleWarning
 from ..namespaces import NAMESPACES
@@ -58,6 +59,8 @@ class RuleParser():
         output = []
         for fix in rule.findall(".//xccdf:fix", NAMESPACES):
             remediation = self.remediation_parser.get_remediation(fix)
+            if remediation.system in HIDDEN_REMEDIATION_TYPES:
+                continue
             output.append(remediation)
         return output
 


### PR DESCRIPTION
This change will cause that Anaconda and Kickstart remediation types will not be shown in the HTML report. Anaconda remediations are consumed only by OSCAP Anaconda Addon. Kickstart remediations are consumed by OpenSCAP to generate a kickstart. It isn't useful to the user at all to see or copy these remediation types, they don't have any use for them. To reduce the unnecessary information in the report, we won't include them in the report.