### PR TITLE
Do not show OVAL details for notapplicable rules

### DIFF
--- a/openscap_report/report_generators/html_templates/rule_detail.html
+++ b/openscap_report/report_generators/html_templates/rule_detail.html
@@ -234,12 +234,14 @@
             </tr>
             {% endif %}
             {% include "remedations.html" %}
-            {% include "oval_definition_detail.html" %}
-            <tr role="row">
-                <td colspan="2" role="cell">
-                    {%- include "oval_graph.html" %}
-                </td>
-            </tr>
+            {% if rule.result != "notapplicable" %}
+                {% include "oval_definition_detail.html" %}
+                <tr role="row">
+                    <td colspan="2" role="cell">
+                        {%- include "oval_graph.html" %}
+                    </td>
+                </tr>
+            {% endif %}
             {% if rule.cpe_tree -%}
                 <tr role="row">
                     <th class="pf-m-fit-content" role="rowheader" scope="row"><b>CPE check:</b></th>


### PR DESCRIPTION
With this patch, we won't show OVAL details for notapplicable rules. The reason is that if a rule is notapplicable the OVAL isn't evaluated at all. Also, the users are interested only in the CPE OVAL.

Fixes: #241