### PR TITLE
Prevent unwanted scrollbars

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -714,7 +714,7 @@ function generate_OVAL_endpoint(div, title, kv_entries, data, referenced_id, tes
     div.appendChild(get_header(title));
     div.appendChild(BR.cloneNode());
     const table_div = DIV.cloneNode();
-    table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
+    table_div.className = "oval-test-detail-table";
     div.appendChild(table_div);
 
     const table = TABLE.cloneNode();
@@ -889,7 +889,7 @@ function get_OVAL_test_info(test_info) {
     div.appendChild(BR.cloneNode());
 
     const table_div = DIV.cloneNode();
-    table_div.className = "pf-c-scroll-inner-wrapper oval-test-detail-table";
+    table_div.className = "oval-test-detail-table";
     div.appendChild(table_div);
 
     const table = TABLE.cloneNode();


### PR DESCRIPTION
This commit will prevent horizontal scrollbars on tables that are vertically organized therefore they don't need horizontal scrollbars.