### PR TITLE
Fix colors in CPE AL details

### DIFF
--- a/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
+++ b/openscap_report/report_generators/html_templates/js/oval_graph_generation_script.js
@@ -167,7 +167,7 @@ function generate_oval_tree(self, div_id_with_oval_graph_data) { // eslint-disab
 }
 
 function get_CPE_AL_tree_node(root) {
-    if (root.node_type == 'frac-ref') {
+    if (root.node_type == 'fact-ref') {
         return undefined;
     }
 
@@ -178,8 +178,8 @@ function get_CPE_AL_tree_node(root) {
         ul.setAttribute('role', "group");
         const fragment = document.createDocumentFragment();
         for (const child of root.children) {
-            if (child.node_type == "frac-ref") {
-                fragment.appendChild(render_CPE_frac_ref(child));
+            if (child.node_type == "fact-ref") {
+                fragment.appendChild(render_CPE_fact_ref(child));
             } else {
                 fragment.appendChild(get_CPE_AL_tree_node(child));
             }
@@ -201,24 +201,15 @@ function get_colors_and_icons(node_data) {
         color = 'pf-m-red';
         icon = 'fa-times';
     }
-
-    let negate_color = '';
-    let negate_icon = icon;
-    if (node_data.negation) {
-        negate_color = COLOR_TRANSLATION[NEGATION_COLOR[color]];
-        negate_icon = NEGATION_ICON[icon];
-    } else {
-        negate_color = COLOR_TRANSLATION[color];
-    }
-    return { color, icon, negate_color, negate_icon };
+    return { color, icon };
 }
 
 
 function base_operator_node(node_data, node_text) {
-    const { color, icon, negate_color, negate_icon } = get_colors_and_icons(node_data);
-    const node = get_node(negate_color);
+    const { color, icon } = get_colors_and_icons(node_data);
+    const node = get_node(COLOR_TRANSLATION[color]);
     node_text.appendChild(node);
-    const html_icon = get_icon_as_html(negate_icon);
+    const html_icon = get_icon_as_html(icon);
     node.appendChild(html_icon);
     if (node_data.negation) {
         node.appendChild(get_operator_label_with_tooltip("NOT", OVAL_OPERATOR_EXPLANATION));
@@ -241,12 +232,12 @@ function get_CPE_AL_operator_node(node_data) {
 }
 
 
-function render_CPE_frac_ref(node_data) {
+function render_CPE_fact_ref(node_data) {
     const { operator_node, node_text } = get_operator_node();
     const { node, color, icon } = base_operator_node(node_data.oval_tree, node_text);
 
     node.appendChild(get_bold_text(` Reference to OVAL definition `));
-    node_text.appendChild(get_label(color, "frac-ref", undefined, "cpe-label"," cpe-label__content"));
+    node_text.appendChild(get_label(color, "fact-ref", undefined, "cpe-label"," cpe-label__content"));
     const span_space = SPAN.cloneNode();
     span_space.innerText = "\u00A0";
     node_text.appendChild(span_space);
@@ -321,11 +312,11 @@ function get_test_node() {
 
 function render_OVAL_test(node_data) {
     const { test_node, node_content, node_text } = get_test_node();
-    const { color, icon, negate_color, negate_icon } = get_colors_and_icons(node_data);
+    const { color, icon } = get_colors_and_icons(node_data);
 
-    const node = get_node(negate_color);
+    const node = get_node(COLOR_TRANSLATION[color]);
     node_text.appendChild(node);
-    const html_icon = get_icon_as_html(negate_icon);
+    const html_icon = get_icon_as_html(icon);
     node.appendChild(html_icon);
     if (node_data.negation) {
         node.appendChild(get_operator_label_with_tooltip("NOT", OVAL_OPERATOR_EXPLANATION));

--- a/openscap_report/scap_results_parser/data_structures/cpe_logical_test.py
+++ b/openscap_report/scap_results_parser/data_structures/cpe_logical_test.py
@@ -31,14 +31,12 @@ class LogicalTest:
         result = Counter(EMPTY_RESULT)
         for child in self.children:
             value = None
-            if child.node_type == "frac-ref":
+            if child.node_type == "fact-ref":
                 value = str(child.oval_tree.evaluate_tree())
             else:
                 value = str(child.evaluate_tree())
 
             node_result = OVAL_RESULT_TO_CPE_RESULT.get(value, "error")
-            if child.negation:
-                node_result = NEGATE_VALUE[value]
             result[f"number_of_{node_result}"] += 1
         return result
 
@@ -48,8 +46,6 @@ class LogicalTest:
             out_result = cpe_result.eval_operator_or()
         elif self.node_type.lower() == "and":
             out_result = cpe_result.eval_operator_and()
-        if out_result is not None:
-            self.value = out_result
         return out_result
 
     def evaluate_tree(self):
@@ -58,4 +54,5 @@ class LogicalTest:
         out_result = self._eval_operator(cpe_result)
         if self.negation:
             out_result = NEGATE_VALUE[out_result]
+        self.value = out_result
         return out_result

--- a/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
+++ b/openscap_report/scap_results_parser/oval_and_cpe_tree_builder.py
@@ -90,7 +90,7 @@ class OVALAndCPETreeBuilder:  # pylint: disable=R0902, R0913
                     logical_test=LogicalTest(
                         node_type="AND",
                         children=[LogicalTest(
-                            node_type="frac-ref",
+                            node_type="fact-ref",
                             value=oval_definition.definition_id,
                             oval_tree=oval_definition.oval_tree
                         )],

--- a/openscap_report/scap_results_parser/parsers/cpe_al_parser.py
+++ b/openscap_report/scap_results_parser/parsers/cpe_al_parser.py
@@ -61,8 +61,7 @@ class CPEApplicabilityLanguageParser:
                 check_id_ref = child_logical_test_el.get("id-ref")
                 logical_test.children.append(
                     LogicalTest(
-                        node_type="frac-ref",
-                        value=platform_name if platform_name is not None else check_id_ref,
+                        node_type="fact-ref",
                         oval_tree=self._get_oval_cpe_tree(platform_name, check_id_ref))
                 )
             if child_logical_test_el.get('operator') is not None:


### PR DESCRIPTION
If negation was used in OVAL check for a CPE platform, the results were red even if the check passed. It was a problem when processing the negation.

In this patch, we will change the logic so that the red and green colors are inverted when negation is used.

Also fixes a typo: frac -> fact.

Fixes: #250
