### PR TITLE
Define relationship with oval-graph package

### DIFF
--- a/openscap-report.spec
+++ b/openscap-report.spec
@@ -23,6 +23,8 @@ Requires:       python3-lxml
 Recommends:     redhat-display-fonts
 Recommends:     redhat-text-fonts
 
+Obsoletes:      oval-graph
+
 %global _description %{expand:
 This package provides a command-line tool for generating
 human-readable reports from SCAP XCCDF and ARF results.}

--- a/spec/rhel8/openscap-report.spec
+++ b/spec/rhel8/openscap-report.spec
@@ -23,6 +23,8 @@ Requires:       python3-jinja2
 Recommends:     redhat-display-fonts
 Recommends:     redhat-text-fonts
 
+Obsoletes:      oval-graph
+
 %{?python_enable_dependency_generator}
 
 %global _description %{expand:


### PR DESCRIPTION
#### Description:

Add `Obsoletes: oval-graph` to spec files.

#### Rationale:

- We are retiring `oval-graph`.